### PR TITLE
destroy sharedmesh in stead of meshes will remove mesh from memory

### DIFF
--- a/3DAmsterdam/Assets/Amsterdam3D/Scripts/LayerSystem/TileHandler.cs
+++ b/3DAmsterdam/Assets/Amsterdam3D/Scripts/LayerSystem/TileHandler.cs
@@ -134,7 +134,7 @@ namespace LayerSystem
                         MeshFilter mf = layers[tileChange.layerIndex].tiles[tileKey].gameObject.GetComponent<MeshFilter>();
                         if (mf != null)
                         {
-                            DestroyImmediate(layers[tileChange.layerIndex].tiles[tileKey].gameObject.GetComponent<MeshFilter>().mesh, true);
+                            DestroyImmediate(layers[tileChange.layerIndex].tiles[tileKey].gameObject.GetComponent<MeshFilter>().sharedMesh, true);
                         }
                         Destroy(layers[tileChange.layerIndex].tiles[tileKey].gameObject);
                         layers[tileChange.layerIndex].tiles.Remove(tileKey);


### PR DESCRIPTION
heb een memoryleak gevonden in de tilehandler die (waarschijnlijk) zorgde voor de out of memory.
in de profiler nam de meshmemory contiue toe. met deze aanpassing neemt de meshmemory netjes af als er tegels verwijderd worden.