### PR TITLE
Release/0.2.2.5

### DIFF
--- a/3DAmsterdam/ProjectSettings/ProjectSettings.asset
+++ b/3DAmsterdam/ProjectSettings/ProjectSettings.asset
@@ -124,7 +124,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: develop
+  bundleVersion: 0.2.2.5
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
@@ -551,7 +551,7 @@ PlayerSettings:
     1: UNITY_POST_PROCESSING_STACK_V2
     4: UNITY_POST_PROCESSING_STACK_V2
     7: UNITY_POST_PROCESSING_STACK_V2
-    13: DEVELOPMENT;UNITY_POST_PROCESSING_STACK_V2
+    13: PRODUCTION;UNITY_POST_PROCESSING_STACK_V2
     14: UNITY_POST_PROCESSING_STACK_V2
     19: UNITY_POST_PROCESSING_STACK_V2
     21: UNITY_POST_PROCESSING_STACK_V2


### PR DESCRIPTION
- new textured tree visualisations with smaller download size
- added tree tile generation scripts to project
- added download link to new downloads page
- fixed memoryleak where downloaded tile meshes were not being destroyed
- fixed coloring/opacity on building materials
- fixed shared materials being destroying causing and error on importing a second .obj
- fixed startup unity splash screen intersection with loadingbar
- added sun 'flare' effect when postprocessing is enabled