### PR TITLE
Bugfix/shadows transparent buildings

### DIFF
--- a/3DAmsterdam/Assets/Amsterdam3D/Materials/BasicObjects/Bomen.mat
+++ b/3DAmsterdam/Assets/Amsterdam3D/Materials/BasicObjects/Bomen.mat
@@ -14,9 +14,8 @@ Material:
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 2050
-  stringTagMap:
-    RenderType: Opaque
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
   disabledShaderPasses: []
   m_SavedProperties:
     serializedVersion: 3

--- a/3DAmsterdam/Assets/Amsterdam3D/Materials/BasicObjects/ShaderSources/Buildings_Opaque.mat
+++ b/3DAmsterdam/Assets/Amsterdam3D/Materials/BasicObjects/ShaderSources/Buildings_Opaque.mat
@@ -8,20 +8,20 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Buildings_Opaque
-  m_Shader: {fileID: -6465566751694194690, guid: cf7aab6d9ec497241842dbbd4b4f979a,
+  m_Shader: {fileID: -6465566751694194690, guid: e716914857da0754cb4b84b9876c0725,
     type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 2000
+  m_CustomRenderQueue: -1
   stringTagMap: {}
   disabledShaderPasses: []
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
     - Texture2D_8DCEAB9E:
-        m_Texture: {fileID: 2800000, guid: 94cc675f6a7489242a79f715ac2eee58, type: 3}
+        m_Texture: {fileID: 2800000, guid: c4dedf4e32876384f96c2b735c361a52, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - Texture2D_D47B27AF:

--- a/3DAmsterdam/Assets/Amsterdam3D/Materials/BasicObjects/ShaderSources/Buildings_Transparent.mat
+++ b/3DAmsterdam/Assets/Amsterdam3D/Materials/BasicObjects/ShaderSources/Buildings_Transparent.mat
@@ -14,7 +14,7 @@ Material:
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
+  m_CustomRenderQueue: 3000
   stringTagMap: {}
   disabledShaderPasses: []
   m_SavedProperties:

--- a/3DAmsterdam/Assets/Amsterdam3D/Materials/BasicObjects/ShaderSources/Buildings_Transparent.mat
+++ b/3DAmsterdam/Assets/Amsterdam3D/Materials/BasicObjects/ShaderSources/Buildings_Transparent.mat
@@ -14,14 +14,14 @@ Material:
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 3000
+  m_CustomRenderQueue: -1
   stringTagMap: {}
   disabledShaderPasses: []
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
     - Texture2D_8DCEAB9E:
-        m_Texture: {fileID: 2800000, guid: 94cc675f6a7489242a79f715ac2eee58, type: 3}
+        m_Texture: {fileID: 2800000, guid: c4dedf4e32876384f96c2b735c361a52, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - Texture2D_D47B27AF:

--- a/3DAmsterdam/Assets/Amsterdam3D/Scripts/Interface/Layers/MaterialSlot.cs
+++ b/3DAmsterdam/Assets/Amsterdam3D/Scripts/Interface/Layers/MaterialSlot.cs
@@ -135,6 +135,8 @@ namespace Amsterdam3D.Interface
 				materialOpacity = opacity;
 				SwitchShaderAccordingToOpacity();
 			}
+
+			targetMaterial.SetShaderPassEnabled("ShadowCaster", (opacity == 1.0f));
 		}
 
 		private void SwitchShaderAccordingToOpacity()


### PR DESCRIPTION
- disabled shadows for shaders with <1.0 opacity