### PR TITLE
set version release number

### DIFF
--- a/3DAmsterdam/ProjectSettings/ProjectSettings.asset
+++ b/3DAmsterdam/ProjectSettings/ProjectSettings.asset
@@ -124,7 +124,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 0.2.2.5
+  bundleVersion: 0.2.2.6
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0


### PR DESCRIPTION
- Camera rotation around point no longer goes underneath the point its Y position
- Height slider according to NAP
- Dragging camera, and holding left mouse no longer keeps on juddering
- Camera movement clamped to bounds, no longer allowing out of view bounds errors
- FPS camera fix, requiring grounding before being able to fall
- Trees now have a quad to give an idea of volume, looking from above
- Dynamic shadow draw distance based on camera height, allowing for higher resolution shadows on close range, en further shadow draw distance
- White placeholder tiles are disabled
- Visual warning dialogs for feedback to users when web requests fail / servers are down
- Memoryleaks solved where sharedMeshes were not being destroyed
- Building selection improvements