### PR TITLE
Bugfix/combine removed sewer tile

### DIFF
--- a/3DAmsterdam/Assets/Amsterdam3D/Scripts/LayerSystem/AssetbundleMeshLayer.cs
+++ b/3DAmsterdam/Assets/Amsterdam3D/Scripts/LayerSystem/AssetbundleMeshLayer.cs
@@ -12,7 +12,7 @@ namespace LayerSystem
     {
         public Material DefaultMaterial;
 
-		public override void onDisableTiles(bool isenabled)
+		public override void OnDisableTiles(bool isenabled)
         {
 
         }

--- a/3DAmsterdam/Assets/Amsterdam3D/Scripts/LayerSystem/Layer.cs
+++ b/3DAmsterdam/Assets/Amsterdam3D/Scripts/LayerSystem/Layer.cs
@@ -22,7 +22,7 @@ namespace LayerSystem
                 {
                     transform.GetChild(i).gameObject.SetActive(isenabled);
                 }
-                onDisableTiles(isenabled);
+                OnDisableTiles(isenabled);
             }
         }
         public int tileSize = 1000;
@@ -31,7 +31,7 @@ namespace LayerSystem
         public Dictionary<Vector2Int, Tile> tiles = new Dictionary<Vector2Int, Tile>();
         public bool pauseLoading = false;
 
-        public abstract void onDisableTiles(bool isenabled);
+        public abstract void OnDisableTiles(bool isenabled);
         public abstract void HandleTile(TileChange tileChange, System.Action<TileChange> callback = null);
 
         public void Start()

--- a/3DAmsterdam/Assets/Amsterdam3D/Scripts/LayerSystem/SewerageLayer.cs
+++ b/3DAmsterdam/Assets/Amsterdam3D/Scripts/LayerSystem/SewerageLayer.cs
@@ -24,7 +24,7 @@ namespace LayerSystem
 		private const int maxParsesPerFrame = 500;
 		private float napOffset = 0;
 
-		public override void onDisableTiles(bool isenabled)
+		public override void OnDisableTiles(bool isenabled)
         {
 			runtimeMaskSphere.enabled = isenabled;
         }
@@ -185,6 +185,9 @@ namespace LayerSystem
 
 		public GameObject CombineSewerage(TileChange tileChange, Tile tile, System.Action<TileChange> callback = null)
 		{
+			//Do not try to combine if our gameobject was already destroyed.
+			if (!tile.gameObject) return null;
+
 			//Determine meshes to combine
 			MeshFilter[] meshFilters = tile.gameObject.GetComponentsInChildren<MeshFilter>(true);
 			CombineInstance[] combine = new CombineInstance[meshFilters.Length];
@@ -197,15 +200,6 @@ namespace LayerSystem
 
 				i++;
 			}
-
-			//GameObject[] allChildren = new GameObject[networkContainer.childCount];
-			//int j = 0;
-			////Find all child obj and store to that array
-			//foreach (Transform child in networkContainer)
-			//{
-			//	allChildren[j] = child.gameObject;
-			//	j++;
-			//}
 
 			//Own combined mesh
 			GameObject newCombinedTile = new GameObject();


### PR DESCRIPTION
Null check before finding meshfilters within tile gameobject. Sometimes gameobject would already be destroyed, throwing a null error.