### PR TITLE
Feature/fix frozen tile handler when highlighting

### DIFF
--- a/3DAmsterdam/Assets/Amsterdam3D/Scripts/BAG-API/SelectByID.cs
+++ b/3DAmsterdam/Assets/Amsterdam3D/Scripts/BAG-API/SelectByID.cs
@@ -202,7 +202,7 @@ public class SelectByID : Interactable
 
     IEnumerator GetSelectedMeshIDData(Ray ray, System.Action<string> callback)
     {
-        tileHandler.pauseLoading = true;
+        
 
         //Check area that we clicked, and add the (heavy) mesh collider there
         Vector3 planeHit = CameraModeChanger.Instance.CurrentCameraControls.GetMousePositionInWorld();
@@ -211,7 +211,7 @@ public class SelectByID : Interactable
         //No fire a raycast towards our meshcolliders to see what face we hit 
         if (Physics.Raycast(ray, out lastRaycastHit, 10000, clickCheckLayerMask.value) == false)
         {
-            tileHandler.pauseLoading = false;
+            
             callback(emptyID);
             yield break;
         }
@@ -222,7 +222,7 @@ public class SelectByID : Interactable
         if (vertexIndex > mesh.uv2.Length) 
         {
             Debug.LogWarning("UV index out of bounds. This object/LOD level does not contain highlight/hidden uv2 slot");
-            tileHandler.pauseLoading = false;
+            
             yield break;
         }
 
@@ -231,7 +231,8 @@ public class SelectByID : Interactable
 
         //Maybe we hit an object with objectdata, that has hidden selections, in that case, loop untill we find something
         ObjectData objectMapping = gameObjectToHighlight.GetComponent<ObjectData>();
-        if(objectMapping && objectMapping.colorIDMap)
+        tileHandler.pauseLoading = true;
+        if (objectMapping && objectMapping.colorIDMap)
         {
             Color hitPixelColor = objectMapping.GetUVColorID(hitUvCoordinate);
             int raysLooped = 0;
@@ -250,6 +251,7 @@ public class SelectByID : Interactable
                 yield return new WaitForEndOfFrame();
             }
         }
+        tileHandler.pauseLoading = false;
         //Not retrieve the selected BAG ID tied to the selected triangle
         containerLayer.GetIDData(gameObjectToHighlight, lastRaycastHit.triangleIndex * 3, HighlightSelectedID);
     }

--- a/3DAmsterdam/Assets/Amsterdam3D/Scripts/BAG-API/SelectByID.cs
+++ b/3DAmsterdam/Assets/Amsterdam3D/Scripts/BAG-API/SelectByID.cs
@@ -231,7 +231,7 @@ public class SelectByID : Interactable
 
         //Maybe we hit an object with objectdata, that has hidden selections, in that case, loop untill we find something
         ObjectData objectMapping = gameObjectToHighlight.GetComponent<ObjectData>();
-        tileHandler.pauseLoading = true;
+        
         if (objectMapping && objectMapping.colorIDMap)
         {
             Color hitPixelColor = objectMapping.GetUVColorID(hitUvCoordinate);
@@ -251,7 +251,7 @@ public class SelectByID : Interactable
                 yield return new WaitForEndOfFrame();
             }
         }
-        tileHandler.pauseLoading = false;
+        
         //Not retrieve the selected BAG ID tied to the selected triangle
         containerLayer.GetIDData(gameObjectToHighlight, lastRaycastHit.triangleIndex * 3, HighlightSelectedID);
     }

--- a/3DAmsterdam/Assets/Amsterdam3D/Scripts/LayerSystem/AssetbundleMeshLayer.cs
+++ b/3DAmsterdam/Assets/Amsterdam3D/Scripts/LayerSystem/AssetbundleMeshLayer.cs
@@ -256,6 +256,7 @@ namespace LayerSystem
 
 		private IEnumerator DownloadObjectData(GameObject obj, int vertexIndex, System.Action<string> callback)
 		{
+			yield return new WaitUntil(() => pauseLoading == false); //wait for opportunity to start
 			pauseLoading = true;
 			var meshFilter = obj.GetComponent<MeshFilter>();
 			if (!meshFilter) yield break;

--- a/3DAmsterdam/Assets/Amsterdam3D/Scripts/LayerSystem/AssetbundleMeshLayer.cs
+++ b/3DAmsterdam/Assets/Amsterdam3D/Scripts/LayerSystem/AssetbundleMeshLayer.cs
@@ -256,6 +256,7 @@ namespace LayerSystem
 
 		private IEnumerator DownloadObjectData(GameObject obj, int vertexIndex, System.Action<string> callback)
 		{
+			pauseLoading = true;
 			var meshFilter = obj.GetComponent<MeshFilter>();
 			if (!meshFilter) yield break;
 


### PR DESCRIPTION
pauseloading is set and reset in downloadObjectdata-function. that is the only place where it is necessary

fixes the situation that terrains and trees stop loading when a building is highlighted