### PR TITLE
Bugfix/share url parameter

### DIFF
--- a/3DAmsterdam/Assets/Amsterdam3D/Prefabs/Camera/GodviewCamera.prefab
+++ b/3DAmsterdam/Assets/Amsterdam3D/Prefabs/Camera/GodviewCamera.prefab
@@ -105,9 +105,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3cebe9adf2e5533468508ad96789c6bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  camera: {fileID: 0}
-  zoomSpeed: 0.5
-  dragFactor: 100
+  cameraComponent: {fileID: 0}
+  zoomSpeed: 0.01
+  spinSpeed: 0.5
+  dragging: 0
+  rotatingAroundPoint: 0
   cameraOffsetForTargetLocation: {x: 100, y: 200, z: -100}
   LockFunctions: 0
 --- !u!114 &8089436527420917118

--- a/3DAmsterdam/Assets/Amsterdam3D/Scripts/Camera/GodViewCamera.cs
+++ b/3DAmsterdam/Assets/Amsterdam3D/Scripts/Camera/GodViewCamera.cs
@@ -170,7 +170,7 @@ namespace Amsterdam3D.CameraMotion
 
         private void Zoom(IAction action)
         {
-            scrollDelta = ActionHandler.actions.GodViewMouse.Zoom.ReadValue<Vector2>().y;
+                scrollDelta = ActionHandler.actions.GodViewMouse.Zoom.ReadValue<Vector2>().y;
 
             //A bug with the new inputsystem only fixed in Unity 2021 causes scroll input to be very low on WebGL builds
 #if UNITY_WEBGL && !UNITY_EDITOR
@@ -332,7 +332,7 @@ namespace Amsterdam3D.CameraMotion
         {
             var heightSpeed = cameraComponent.transform.position.y; //The higher we are, the faster we zoom
             zoomDirection = (zoomDirectionPoint - cameraComponent.transform.position).normalized;
-            cameraComponent.transform.Translate(zoomDirection * zoomSpeed * zoomAmount * heightSpeed * Time.deltaTime, Space.World);
+            cameraComponent.transform.Translate(zoomDirection * zoomSpeed * zoomAmount * heightSpeed, Space.World);
             focusingOnTargetPoint.Invoke(zoomDirectionPoint);
         }
 

--- a/3DAmsterdam/Assets/Amsterdam3D/Scripts/Interface/PlaceOnClick.cs
+++ b/3DAmsterdam/Assets/Amsterdam3D/Scripts/Interface/PlaceOnClick.cs
@@ -10,7 +10,7 @@ namespace Amsterdam3D.Interface
     [RequireComponent(typeof(WorldPointFollower))]
 	public class PlaceOnClick : Interactable, IDragHandler
     {
-       public bool waitingForClick = true;
+        public bool waitingForClick = true;
         private IAction placeAction;
 
         private WorldPointFollower worldPointerFollower;

--- a/3DAmsterdam/Assets/Amsterdam3D/Scripts/Interface/PlaceOnClick.cs
+++ b/3DAmsterdam/Assets/Amsterdam3D/Scripts/Interface/PlaceOnClick.cs
@@ -29,8 +29,11 @@ namespace Amsterdam3D.Interface
         {
             ActionMap = ActionHandler.actions.PlaceOnClick;
             placeAction = ActionHandler.instance.GetAction(ActionHandler.actions.PlaceOnClick.Place);
-            placeAction.SubscribePerformed(Place);
-            PlaceUsingPointer();
+            if (waitingForClick)
+            {
+                placeAction.SubscribePerformed(Place);
+                PlaceUsingPointer();
+            }
         }
 
         public virtual void OnDrag(PointerEventData eventData)

--- a/3DAmsterdam/Assets/Amsterdam3D/Scripts/Sharing/SceneSerializer.cs
+++ b/3DAmsterdam/Assets/Amsterdam3D/Scripts/Sharing/SceneSerializer.cs
@@ -65,7 +65,9 @@ namespace Amsterdam3D.Sharing
 
         private void Start()
         {
-            if (Application.absoluteURL.Contains(urlViewIDVariable)){
+            if (Application.absoluteURL.Contains(urlViewIDVariable))
+            {
+                var urlVariables = Application.absoluteURL.Split('=');
                 StartCoroutine(GetSharedScene(Application.absoluteURL.Split('=')[1]));
             }
             customMeshObjects = new List<GameObject>();

--- a/3DAmsterdam/Assets/Amsterdam3D/Scripts/Sharing/SceneSerializer.cs
+++ b/3DAmsterdam/Assets/Amsterdam3D/Scripts/Sharing/SceneSerializer.cs
@@ -75,7 +75,7 @@ namespace Amsterdam3D.Sharing
 		private void CheckURLForSharedSceneID()
 		{
             //HttpUtility not embedded in Unity's .net integration, so lets just filter out the ID ourselves
-            if (Application.absoluteURL.Contains("?" + urlViewIDVariable + "=") || Application.absoluteURL.Contains("&" + urlViewIDVariable + "="))
+            if (Application.absoluteURL.Contains("?" + urlViewIDVariable) || Application.absoluteURL.Contains("&" + urlViewIDVariable))
 			{
                 var uniqueSceneID = Application.absoluteURL.Split(new string[] { urlViewIDVariable }, StringSplitOptions.None)[1].Split('&')[0].Split('#')[0];
 				StartCoroutine(GetSharedScene(uniqueSceneID));
@@ -152,6 +152,7 @@ namespace Amsterdam3D.Sharing
                 annotation.WorldPointerFollower.WorldPosition = new Vector3(annotationData.position.x, annotationData.position.y, annotationData.position.z);
                 annotation.BodyText = annotationData.bodyText;
                 annotation.AllowEdit = scene.allowSceneEdit;
+                annotation.waitingForClick = false;
 
                 //Create a custom annotation layer
                 CustomLayer newCustomAnnotationLayer = interfaceLayers.AddNewCustomObjectLayer(annotation.gameObject, LayerType.ANNOTATION, false);
@@ -168,6 +169,7 @@ namespace Amsterdam3D.Sharing
                 SerializableScene.CustomLayer customLayer = scene.customLayers[i];
                 GameObject customObject = new GameObject();
                 customObject.name = customLayer.layerName;
+                if(scene.allowSceneEdit) customObject.AddComponent<Interactable>();
                 ApplyLayerMaterialsToObject(customLayer, customObject);
 
                 CustomLayer newCustomLayer = interfaceLayers.AddNewCustomObjectLayer(customObject, LayerType.OBJMODEL, false);
@@ -181,7 +183,7 @@ namespace Amsterdam3D.Sharing
                 StartCoroutine(GetCustomMeshObject(customObject, sceneId, customLayer.token, customLayer.position, customLayer.rotation, customLayer.scale));
             }
 
-            // create all custom camera points
+            //Create all custom camera points
             for (int i = 0; i < scene.cameraPoints.Length; i++) 
             {
                 SerializableScene.CameraPoint cameraPoint = scene.cameraPoints[i];

--- a/3DAmsterdam/Assets/Amsterdam3D/Scripts/Sharing/SceneSerializer.cs
+++ b/3DAmsterdam/Assets/Amsterdam3D/Scripts/Sharing/SceneSerializer.cs
@@ -3,6 +3,8 @@ using Amsterdam3D.Interface;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+using System.Web;
 using UnityEngine;
 using UnityEngine.Networking;
 using UnityEngine.Rendering;
@@ -43,8 +45,7 @@ namespace Amsterdam3D.Sharing
         [SerializeField]
         private InterfaceLayer groundLayer;
 
-        [SerializeField]
-        private string urlViewIDVariable = "?view=";
+        private string urlViewIDVariable = "view=";
 
         private List<GameObject> customMeshObjects;
 
@@ -64,21 +65,29 @@ namespace Amsterdam3D.Sharing
         private GameObject[] objectsRemovedInViewMode;
 
         private void Start()
-        {
-            if (Application.absoluteURL.Contains(urlViewIDVariable))
-            {
-                var urlVariables = Application.absoluteURL.Split('=');
-                StartCoroutine(GetSharedScene(Application.absoluteURL.Split('=')[1]));
-            }
-            customMeshObjects = new List<GameObject>();
-        }
+		{
+            //Optionaly load an existing scene if we supplied a 'view=' id in the url parameters.
+			CheckURLForSharedSceneID();
 
-        #if UNITY_EDITOR
-        /// <summary>
-        /// This test method allows you to right click this MonoBehaviour in the editor.
-        /// And test the downloading of a specific sharedSceneId.
-        /// </summary>
-        [ContextMenu("Load last saved ID")] 
+			customMeshObjects = new List<GameObject>();
+		}
+
+		private void CheckURLForSharedSceneID()
+		{
+            //HttpUtility not embedded in Unity's .net integration, so lets just filter out the ID ourselves
+            if (Application.absoluteURL.Contains("?" + urlViewIDVariable + "=") || Application.absoluteURL.Contains("&" + urlViewIDVariable + "="))
+			{
+                var uniqueSceneID = Application.absoluteURL.Split(new string[] { urlViewIDVariable }, StringSplitOptions.None)[1].Split('&')[0].Split('#')[0];
+				StartCoroutine(GetSharedScene(uniqueSceneID));
+			}
+		}
+
+#if UNITY_EDITOR
+		/// <summary>
+		/// This test method allows you to right click this MonoBehaviour in the editor.
+		/// And test the downloading of a specific sharedSceneId.
+		/// </summary>
+		[ContextMenu("Load last saved ID")] 
         public void GetTestId(){
             if (sharedSceneId != "") StartCoroutine(GetSharedScene(sharedSceneId));
         }


### PR DESCRIPTION
- solved issue where view parameter was wrong, if multiple url variables were used. now it should not matter where it is in the url.
- removed delta time caclulation when zooming (we were doing this two times)
- solved problem where loading a shared scene would stick annotations or camera positions to mouse directly