### PR TITLE
Bugfix/greyed out transform

### DIFF
--- a/3DAmsterdam/Assets/Amsterdam3D/Prefabs/UI/ContextMenu/ContextMenu.prefab
+++ b/3DAmsterdam/Assets/Amsterdam3D/Prefabs/UI/ContextMenu/ContextMenu.prefab
@@ -518,7 +518,7 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 3301187063397059509}
+        - m_Target: {fileID: 4058696454881948662}
           m_MethodName: SetActive
           m_Mode: 6
           m_Arguments:
@@ -653,6 +653,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   contextItemsPanel: {fileID: 1608703166506704137}
+  transformSubmenuItem: {fileID: 7484661785634329744}
   transformSubMenu: {fileID: 5425281213076131366}
   state: 0
   buttonsAvailableOnState:
@@ -2080,12 +2081,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d0e458a3243dffe409b24f961f748026, type: 3}
---- !u!1 &3301187063397059509 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 5133045643977663368, guid: d0e458a3243dffe409b24f961f748026,
-    type: 3}
-  m_PrefabInstance: {fileID: 7704552810712541245}
-  m_PrefabAsset: {fileID: 0}
 --- !u!224 &5425281213076131366 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 2424741384037787163, guid: d0e458a3243dffe409b24f961f748026,

--- a/3DAmsterdam/Assets/Amsterdam3D/Scripts/BAG-API/SelectByID.cs
+++ b/3DAmsterdam/Assets/Amsterdam3D/Scripts/BAG-API/SelectByID.cs
@@ -153,7 +153,7 @@ public class SelectByID : Interactable
             }
             ObjectProperties.Instance.RenderThumbnail(true);
         }
-		else
+		else if(ContextPointerMenu.Instance.state != ContextPointerMenu.ContextState.CUSTOM_OBJECTS)
 		{
             ContextPointerMenu.Instance.SwitchState(ContextPointerMenu.ContextState.DEFAULT);
 		}
@@ -170,7 +170,10 @@ public class SelectByID : Interactable
 			selectedIDs.Clear();
         }
 
-        ContextPointerMenu.Instance.SwitchState(ContextPointerMenu.ContextState.DEFAULT);
+        if (ContextPointerMenu.Instance.state != ContextPointerMenu.ContextState.CUSTOM_OBJECTS)
+        {
+            ContextPointerMenu.Instance.SwitchState(ContextPointerMenu.ContextState.DEFAULT);
+        }
 
         //Remove highlights by highlighting our empty list
         containerLayer.Highlight(selectedIDs);

--- a/3DAmsterdam/Assets/Amsterdam3D/Scripts/Interface/ContextPointerMenu/ContextPointerMenu.cs
+++ b/3DAmsterdam/Assets/Amsterdam3D/Scripts/Interface/ContextPointerMenu/ContextPointerMenu.cs
@@ -15,6 +15,8 @@ namespace Amsterdam3D.Interface
 		private RectTransform contextItemsPanel = default;
 
 		[SerializeField]
+		private Button transformSubmenuItem;
+		[SerializeField]
 		private RectTransform transformSubMenu = default;
 
 		public static ContextPointerMenu Instance = null;
@@ -112,6 +114,17 @@ namespace Amsterdam3D.Interface
 						button.interactable = true;
 					return;
 				}
+			}
+		}
+
+		/// <summary>
+		/// Pops out transform options if the button is active
+		/// </summary>
+		public void PopOutTransformSubmenu()
+		{
+			if (transformSubmenuItem.interactable)
+			{
+				transformSubMenu.gameObject.SetActive(true);
 			}
 		}
 

--- a/3DAmsterdam/Assets/Amsterdam3D/Scripts/RuntimeHandle/RuntimeTransformHandle.cs
+++ b/3DAmsterdam/Assets/Amsterdam3D/Scripts/RuntimeHandle/RuntimeTransformHandle.cs
@@ -46,6 +46,8 @@ namespace RuntimeHandle
 
         void Awake()
         {
+            contextMenuState = ContextPointerMenu.ContextState.CUSTOM_OBJECTS;
+
             raycastLayer = LayerMask.NameToLayer(raycastLayerName);
 
             movedHandle = new UnityEvent();
@@ -81,6 +83,12 @@ namespace RuntimeHandle
             if (positionHandle) positionHandle.Destroy();
             if (rotationHandle) rotationHandle.Destroy();
             if (scaleHandle) scaleHandle.Destroy();
+        }
+
+        public override void SecondarySelect()
+        {
+            base.Select();
+            ContextPointerMenu.Instance.SetTargetInteractable(target.GetComponent<Interactable>());
         }
 
         void LateUpdate()

--- a/3DAmsterdam/Assets/Scenes/Main.unity
+++ b/3DAmsterdam/Assets/Scenes/Main.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9747e7109d8f0b511d897bc8f25ad122ea7a51a5844f7f40aa29d540f0b70c21
-size 514951
+oid sha256:56ae3c78a378fd07c842c3893a5a24a2f5316ae5c29d393c7060ca3cbf78ab1a
+size 515484


### PR DESCRIPTION
- do not allow setting context menu to default from SelectById if we have it set to custom object properties
- target transformable target when we right click a gizmo