### PR TITLE
set release version number

### DIFF
--- a/3DAmsterdam/ProjectSettings/ProjectSettings.asset
+++ b/3DAmsterdam/ProjectSettings/ProjectSettings.asset
@@ -124,7 +124,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 0.2.3.1
+  bundleVersion: 0.2.3.2
   preloadedAssets:
   - {fileID: 11400000, guid: d5f272a8231831941994b3ff3281aa1d, type: 2}
   metroInputSource: 0


### PR DESCRIPTION
- Snapshot feature added to main menu allowing users to create snapshots of the 3D view with options to hide menu items, and change the output resolution
- Draggable/auto ordering 'floating' panels
- Solved bug where the contextmenu 'Transform' options were greyed out or unavailable when hovering a 3D gizmo