### PR TITLE
Clamped grouped fps between 5->200

### DIFF
--- a/3DAmsterdam/Assets/Amsterdam3D/Scripts/Interface/Fps.cs
+++ b/3DAmsterdam/Assets/Amsterdam3D/Scripts/Interface/Fps.cs
@@ -117,7 +117,7 @@ namespace Amsterdam3D.Interface
 		/// <param name="fps">The avarage framerate count at this time of logging</param>
 		private void LogFPS(float fps)
 		{
-			int fpsLogGroup = Mathf.RoundToInt(Mathf.Round(fps / analyticsFpsGroupSize) * analyticsFpsGroupSize);
+			int fpsLogGroup = Mathf.Clamp(Mathf.RoundToInt(Mathf.Round(fps / analyticsFpsGroupSize) * analyticsFpsGroupSize), analyticsFpsGroupSize, 200);			
 			Debug.Log("Analytics: fpsGroup " + fpsLogGroup);
 			Analytics.CustomEvent("FPS",
 			new Dictionary<string, object>


### PR DESCRIPTION
Clamped grouped fps between 5->200. This way the average of the groupedFps analytics already filters out the extremes. We should ignore ticks of 0, those probably are idle/inactive tabs.