### PR TITLE
removed namespace from objectmapping class used in our assetbundles. …

### DIFF
--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/LayerSystem/ObjectMappingClass.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/LayerSystem/ObjectMappingClass.cs
@@ -2,14 +2,11 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Netherlands3D.LayerSystem
+public class ObjectMappingClass : ScriptableObject
 {
-    public class ObjectMappingClass : ScriptableObject
-    {
-        public List<string> ids;
-        public List<int> triangleCount;
-        public List<Vector2> mappedUVs;
-        public Vector2[] uvs;
-        public List<int> vectorMap;
-    }
+    public List<string> ids;
+    public List<int> triangleCount;
+    public List<Vector2> mappedUVs;
+    public Vector2[] uvs;
+    public List<int> vectorMap;
 }


### PR DESCRIPTION
removed namespace of objectmappingclass (this should match the one in the assetbundles)