### PR TITLE
 Bugfix/grid stays in fps

### DIFF
--- a/3DAmsterdam/Assets/3DAmsterdam/Scenes/3DAmsterdam.unity
+++ b/3DAmsterdam/Assets/3DAmsterdam/Scenes/3DAmsterdam.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3128599cd9221ac5c5984478334bba1f5c73ead46e9602eda5904719261a13d2
-size 520816
+oid sha256:1ba8f10bcd77617d343a04dfb2678db5f6a547473f4ee363da4bb31ccb3d2530
+size 522269

--- a/3DAmsterdam/Assets/3DAmsterdam/Scenes/3DAmsterdam.unity
+++ b/3DAmsterdam/Assets/3DAmsterdam/Scenes/3DAmsterdam.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1ba8f10bcd77617d343a04dfb2678db5f6a547473f4ee363da4bb31ccb3d2530
-size 522269
+oid sha256:e5fb30007f9193a162d7ead3977b5fb0cf86a308c007fb21f4af0c200009d90f
+size 523436

--- a/3DAmsterdam/Assets/Netherlands3D/Prefabs/Camera/CameraModeChanger.prefab
+++ b/3DAmsterdam/Assets/Netherlands3D/Prefabs/Camera/CameraModeChanger.prefab
@@ -48,6 +48,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   godViewCam: {fileID: 4093344675420705374}
+  groundTransitionOffset: 0
 --- !u!114 &8852100570403522361
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -152,6 +153,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Enabled
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8014012090906924388, guid: ab6da9ff3a357104f884fac01a2076e8,
+        type: 3}
+      propertyPath: disableWhenActive.Array.data[0]
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 9175618376203658408, guid: ab6da9ff3a357104f884fac01a2076e8,
         type: 3}

--- a/3DAmsterdam/Assets/Netherlands3D/Prefabs/Camera/FirstPersonCamera.prefab
+++ b/3DAmsterdam/Assets/Netherlands3D/Prefabs/Camera/FirstPersonCamera.prefab
@@ -50,8 +50,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6b5095b9a18dff249aeb8c84bcd50fe3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  terrainContainerLayer: {fileID: 0}
   speed: 3
   mainMenu: {fileID: 0}
+  hideMenuButton: {fileID: 0}
+  exitFirstPersonButton: {fileID: 0}
+  disableWhenActive:
+  - {fileID: 0}
   interfaceLayers: {fileID: 0}
 --- !u!114 &3272134606442253111
 MonoBehaviour:
@@ -65,6 +70,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7bd73c13c2739cc4ba881917b614a0f0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  terrainContainerLayer: {fileID: 0}
   groundOffset: 1.8
   layerMaskGround:
     serializedVersion: 2
@@ -74,6 +80,7 @@ MonoBehaviour:
     m_Bits: 1025
   moveSpeed: 5
   runspeed: 8
+  actionAsset: {fileID: 0}
 --- !u!114 &6092253054437786300
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/3DAmsterdam/Assets/Netherlands3D/Prefabs/UI/Canvas.prefab
+++ b/3DAmsterdam/Assets/Netherlands3D/Prefabs/UI/Canvas.prefab
@@ -1792,15 +1792,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0a68c256127c6cc4b8b4587db84d29a5, type: 3}
---- !u!224 &2564386842741505194 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 4006015341154517907, guid: 0a68c256127c6cc4b8b4587db84d29a5,
-    type: 3}
-  m_PrefabInstance: {fileID: 1445287717134745401}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &6974130832539062422 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 8414877565509578671, guid: 0a68c256127c6cc4b8b4587db84d29a5,
+    type: 3}
+  m_PrefabInstance: {fileID: 1445287717134745401}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &2564386842741505194 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4006015341154517907, guid: 0a68c256127c6cc4b8b4587db84d29a5,
     type: 3}
   m_PrefabInstance: {fileID: 1445287717134745401}
   m_PrefabAsset: {fileID: 0}
@@ -2824,6 +2824,18 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 6930576189845357148, guid: 7cfbd80cff289264fa095e83062304ae, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 7cfbd80cff289264fa095e83062304ae, type: 3}
+--- !u!1 &605953282063926250 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1696206935778776190, guid: 7cfbd80cff289264fa095e83062304ae,
+    type: 3}
+  m_PrefabInstance: {fileID: 2297649947035752340}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &8545006572231225171 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7599562963145111751, guid: 7cfbd80cff289264fa095e83062304ae,
+    type: 3}
+  m_PrefabInstance: {fileID: 2297649947035752340}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &120734676061445784 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2183696030610229516, guid: 7cfbd80cff289264fa095e83062304ae,
@@ -2836,18 +2848,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9356d64e9f0ff1d4f8f6da6e1966ccb9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &8545006572231225171 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7599562963145111751, guid: 7cfbd80cff289264fa095e83062304ae,
-    type: 3}
-  m_PrefabInstance: {fileID: 2297649947035752340}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &605953282063926250 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1696206935778776190, guid: 7cfbd80cff289264fa095e83062304ae,
-    type: 3}
-  m_PrefabInstance: {fileID: 2297649947035752340}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3039488359212404575
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3646,6 +3646,21 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1400334838243756320, guid: ff13554cc39e8a149adab3002a55054e,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1400334838243756320, guid: ff13554cc39e8a149adab3002a55054e,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 3927131928396795083}
+    - target: {fileID: 1400334838243756320, guid: ff13554cc39e8a149adab3002a55054e,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: ToggleLinkedObject
+      objectReference: {fileID: 0}
     - target: {fileID: 1593283887738346573, guid: ff13554cc39e8a149adab3002a55054e,
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
@@ -4203,6 +4218,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ff13554cc39e8a149adab3002a55054e, type: 3}
+--- !u!114 &3927131928396795083 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7370498977760890426, guid: ff13554cc39e8a149adab3002a55054e,
+    type: 3}
+  m_PrefabInstance: {fileID: 5780014341956748017}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cc99f9dec8005e442b69b78d710325b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &8989622529425738894 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3240113862728207999, guid: ff13554cc39e8a149adab3002a55054e,
@@ -6051,15 +6078,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c347d5ce287732041bc432a1117acd02, type: 3}
---- !u!224 &2620048045572433134 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 4900175362733803871, guid: c347d5ce287732041bc432a1117acd02,
-    type: 3}
-  m_PrefabInstance: {fileID: 6943614216806051249}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &7471411654695368249 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 572912662418496392, guid: c347d5ce287732041bc432a1117acd02,
+    type: 3}
+  m_PrefabInstance: {fileID: 6943614216806051249}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &2620048045572433134 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4900175362733803871, guid: c347d5ce287732041bc432a1117acd02,
     type: 3}
   m_PrefabInstance: {fileID: 6943614216806051249}
   m_PrefabAsset: {fileID: 0}

--- a/3DAmsterdam/Assets/Netherlands3D/Prefabs/UI/Layers/InterfaceLayers.prefab
+++ b/3DAmsterdam/Assets/Netherlands3D/Prefabs/UI/Layers/InterfaceLayers.prefab
@@ -989,8 +989,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4484867641558895107, guid: 7ff0f9ebef801c9449f4d40d66bb5a1a,
         type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4484867641558895107, guid: 7ff0f9ebef801c9449f4d40d66bb5a1a,
+        type: 3}
       propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4484867641558895107, guid: 7ff0f9ebef801c9449f4d40d66bb5a1a,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4484867641558895107, guid: 7ff0f9ebef801c9449f4d40d66bb5a1a,
         type: 3}
@@ -999,13 +1009,33 @@ PrefabInstance:
       objectReference: {fileID: 7370498977760890426}
     - target: {fileID: 4484867641558895107, guid: 7ff0f9ebef801c9449f4d40d66bb5a1a,
         type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 4484867641558895107, guid: 7ff0f9ebef801c9449f4d40d66bb5a1a,
+        type: 3}
       propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4484867641558895107, guid: 7ff0f9ebef801c9449f4d40d66bb5a1a,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4484867641558895107, guid: 7ff0f9ebef801c9449f4d40d66bb5a1a,
         type: 3}
       propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: ToggleLinkedObject
+      objectReference: {fileID: 0}
+    - target: {fileID: 4484867641558895107, guid: 7ff0f9ebef801c9449f4d40d66bb5a1a,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: ResetToDefault
+      objectReference: {fileID: 0}
+    - target: {fileID: 4484867641558895107, guid: 7ff0f9ebef801c9449f4d40d66bb5a1a,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 4524246861349935926, guid: 7ff0f9ebef801c9449f4d40d66bb5a1a,
         type: 3}

--- a/3DAmsterdam/Assets/Netherlands3D/Prefabs/UI/MainMenu/MainMenu.prefab
+++ b/3DAmsterdam/Assets/Netherlands3D/Prefabs/UI/MainMenu/MainMenu.prefab
@@ -848,15 +848,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 39658359fa9dff740a6639817b1915a4, type: 3}
---- !u!224 &5864618508266308583 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 8729436291002256460, guid: 39658359fa9dff740a6639817b1915a4,
-    type: 3}
-  m_PrefabInstance: {fileID: 2902147164584202155}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &5864618508266308584 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 8729436291002256451, guid: 39658359fa9dff740a6639817b1915a4,
+    type: 3}
+  m_PrefabInstance: {fileID: 2902147164584202155}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &5864618508266308583 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8729436291002256460, guid: 39658359fa9dff740a6639817b1915a4,
     type: 3}
   m_PrefabInstance: {fileID: 2902147164584202155}
   m_PrefabAsset: {fileID: 0}
@@ -1424,6 +1424,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1425487515461630822, guid: 24bedb4c22ec52f4998771d342507e14,
+        type: 3}
+      propertyPath: defaultToolSelection
+      value: 
+      objectReference: {fileID: 5165171723378130}
     - target: {fileID: 7971083455747976653, guid: 24bedb4c22ec52f4998771d342507e14,
         type: 3}
       propertyPath: m_Name
@@ -1431,6 +1436,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 24bedb4c22ec52f4998771d342507e14, type: 3}
+--- !u!1 &5165171723378130 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5031283479280300368, guid: 24bedb4c22ec52f4998771d342507e14,
+    type: 3}
+  m_PrefabInstance: {fileID: 5026276774704426114}
+  m_PrefabAsset: {fileID: 0}
 --- !u!224 &5271862826799634421 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 930423608259853175, guid: 24bedb4c22ec52f4998771d342507e14,
@@ -1886,18 +1897,6 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 8729436291002256461, guid: 39658359fa9dff740a6639817b1915a4, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 39658359fa9dff740a6639817b1915a4, type: 3}
---- !u!224 &666169196225268121 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 8729436291002256460, guid: 39658359fa9dff740a6639817b1915a4,
-    type: 3}
-  m_PrefabInstance: {fileID: 8078196956264351189}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &666169196225268118 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 8729436291002256451, guid: 39658359fa9dff740a6639817b1915a4,
-    type: 3}
-  m_PrefabInstance: {fileID: 8078196956264351189}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &666169196225268123 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 8729436291002256462, guid: 39658359fa9dff740a6639817b1915a4,
@@ -1910,6 +1909,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &666169196225268121 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8729436291002256460, guid: 39658359fa9dff740a6639817b1915a4,
+    type: 3}
+  m_PrefabInstance: {fileID: 8078196956264351189}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &666169196225268118 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8729436291002256451, guid: 39658359fa9dff740a6639817b1915a4,
+    type: 3}
+  m_PrefabInstance: {fileID: 8078196956264351189}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8997442991661375913
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Interface/Menu/SwitchTool.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Interface/Menu/SwitchTool.cs
@@ -7,12 +7,22 @@ using UnityEngine.UI;
 namespace Netherlands3D.Interface.Menu {
 	public class SwitchTool : MonoBehaviour
 	{
+		public static SwitchTool Instance;
+
 		private Button[] containingButtons;
 
 		private bool expanded = false;
 
 		[SerializeField]
 		private float spacing = 50;
+
+		[SerializeField]
+		private GameObject defaultToolSelection;
+
+		private void Awake()
+		{
+			Instance = this;
+		}
 
 		void Start()
 		{
@@ -30,6 +40,15 @@ namespace Netherlands3D.Interface.Menu {
 			{
 				containingButtons[i].gameObject.SetActive((containingButtons[i].transform.GetSiblingIndex() == 0));
 			}
+		}
+
+		/// <summary>
+		/// Simple force a click on our default pointer button, selecting our set default tool
+		/// </summary>
+		public void ResetToDefault()
+		{
+			defaultToolSelection.GetComponent<Button>().onClick.Invoke();
+			HideToolButtons();
 		}
 
 		private void AlignToolButtonsSideBySide()

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Streetview/FirstPersonLocation.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Streetview/FirstPersonLocation.cs
@@ -1,4 +1,5 @@
 ﻿using Netherlands3D.Cameras;
+using Netherlands3D.Interface.Menu;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -20,7 +21,7 @@ namespace Netherlands3D.Interface
 		public override void Start()
 		{
 			base.Start();
-
+			SwitchTool.Instance.ResetToDefault();
 			cameraModeChanger = CameraModeChanger.Instance;
 			cameraModeChanger.OnGodViewModeEvent += EnableObject;
 			cameraModeChanger.OnFirstPersonModeEvent += DisableObject;

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Streetview/StreetViewCamera.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Streetview/StreetViewCamera.cs
@@ -33,6 +33,7 @@ namespace Netherlands3D.Cameras
 		private void OnEnable()
 		{
 			cameraComponent = GetComponent<Camera>();
+
 			exitFirstPersonButton.gameObject.SetActive(false);
 			DisableMenus();
 		}

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Streetview/StreetViewCamera.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Streetview/StreetViewCamera.cs
@@ -152,7 +152,8 @@ namespace Netherlands3D.Cameras
 			var pointerPosition = Input.mousePosition;
 			if (optionalPositionOverride != default) pointerPosition = optionalPositionOverride;
 
-			ray = cameraComponent.ScreenPointToRay(pointerPosition);
+			if(cameraComponent)
+				ray = cameraComponent.ScreenPointToRay(pointerPosition);
 			
 			float distance = 99;
 			if (Physics.Raycast(ray, out hit, distance))


### PR DESCRIPTION
disable grid selection tool when selecting underground layer or when going into fps, and removed null error.