### PR TITLE
corrected Mathf.Sqrt calc with negative number that causes an exception

### DIFF
--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Cameras/GodViewCamera.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Cameras/GodViewCamera.cs
@@ -316,7 +316,7 @@ namespace Netherlands3D.Cameras
 
         void HandleTranslationInput()
         {         
-            moveSpeed = Mathf.Sqrt(cameraComponent.transform.position.y) * speedFactor;
+            moveSpeed = Mathf.Sqrt(Mathf.Abs(cameraComponent.transform.position.y)) * speedFactor;
 
             var heightchange = moveHeightActionKeyboard.ReadValue<float>();
             Vector3 movement = moveActionKeyboard.ReadValue<Vector2>();


### PR DESCRIPTION
fixed height slider that causes an exception when doing Mathf.Sqrt calc with negative number