### PR TITLE
Bugfix/ignore fps throttled tab

### DIFF
--- a/3DAmsterdam/Assets/Netherlands3D/Prefabs/UI/FpsPanel.prefab
+++ b/3DAmsterdam/Assets/Netherlands3D/Prefabs/UI/FpsPanel.prefab
@@ -90,9 +90,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   fpsCounter: {fileID: 2208685251058266772}
   fpsBackground: {fileID: 2798071469444078161}
-  logFpsGroupsToAnalytics: 1
-  updateAnalyticsInterval: 10
-  analyticsFpsGroupSize: 5
   badFpsThreshold: 10
   updateInterval: 0.5
 --- !u!1 &8961631062717988770
@@ -108,7 +105,7 @@ GameObject:
   - component: {fileID: 2208685251058266772}
   - component: {fileID: 4723344759794404093}
   m_Layer: 5
-  m_Name: FpsCounter
+  m_Name: FpsCounterText
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Interface/Fps.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Interface/Fps.cs
@@ -39,13 +39,15 @@ namespace Netherlands3D.Interface
 		[SerializeField]
 		private float updateInterval = 0.5f;
 
+		private bool applicationIsActive = true;
+
 		private void Awake()
 		{
 			ToggleVisualFPS(false);
 
 			framesVisualFPS = 0;
 			lastInterval = Time.realtimeSinceStartup;
-
+			
 			#if !UNITY_EDITOR
 			lastIntervalAnalytics = Time.realtimeSinceStartup;
 			framesAnalytics = 0;
@@ -55,6 +57,17 @@ namespace Netherlands3D.Interface
 		private void Update()
 		{
 			CalculateAverageFPS();
+		}
+
+		/// <summary>
+		/// Method we call from javascript, telling unity if the tab/application is active.
+		/// Browsers throttle down applications in background tabs (to 1 fps) so we want to ignore those fps counts.
+		/// </summary>
+		/// <param name="isActive">Is the application active in the foreground, running at max performance</param>
+		public void Active(bool isActive)
+		{
+			Debug.Log("Javascript told Unity that the application is " + isActive);
+			applicationIsActive = isActive;
 		}
 
 		/// <summary>
@@ -88,7 +101,7 @@ namespace Netherlands3D.Interface
 			}
 
 #if !UNITY_EDITOR
-			if(logFpsGroupsToAnalytics)
+			if(logFpsGroupsToAnalytics && applicationIsActive)
 			{
 				++framesAnalytics;
 				if (timeNow > lastIntervalAnalytics + updateAnalyticsInterval)

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Interface/Fps.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Interface/Fps.cs
@@ -63,11 +63,12 @@ namespace Netherlands3D.Interface
 		/// Method we call from javascript, telling unity if the tab/application is active.
 		/// Browsers throttle down applications in background tabs (to 1 fps) so we want to ignore those fps counts.
 		/// </summary>
-		/// <param name="isActive">Is the application active in the foreground, running at max performance</param>
-		public void Active(bool isActive)
+		/// <param name="isActive">Is the application active in the foreground, running at max performance, this should be 1, else 0.</param>
+		public void ActiveApplication(float isActive)
 		{
-			Debug.Log("Javascript told Unity that the application is " + isActive);
-			applicationIsActive = isActive;
+			bool active = (isActive == 1); //We convert a number to a bool ( SendMessage from javascript only supports strings and numbers ) 
+			Debug.Log("Javascript told Unity that the application is " + active);
+			applicationIsActive = active;
 		}
 
 		/// <summary>

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Interface/Fps.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Interface/Fps.cs
@@ -61,18 +61,6 @@ namespace Netherlands3D.Interface
 		}
 
 		/// <summary>
-		/// Method we call from javascript, telling unity if the tab/application is active.
-		/// Browsers throttle down applications in background tabs (to 1 fps) so we want to ignore those fps counts.
-		/// </summary>
-		/// <param name="isActive">Is the application active in the foreground, running at max performance, this should be 1, else 0.</param>
-		public void ActiveApplication(float isActive)
-		{
-			bool active = (isActive == 1); //We convert a number to a bool ( SendMessage from javascript only supports strings and numbers ) 
-			Debug.Log("Javascript told Unity that the application is " + active);
-			applicationIsActive = active;
-		}
-
-		/// <summary>
 		/// Shows or hides the visual FPS number in the screen
 		/// </summary>
 		/// <param name="enabled"></param>
@@ -125,8 +113,8 @@ namespace Netherlands3D.Interface
 			fpsCounter.text = Mathf.Round(fps).ToString();
 			fpsCounter.color = Color.Lerp(Color.red, Color.green, Mathf.InverseLerp(badFpsThreshold, goodFpsThreshold, fps));
 		}
-		
-		#if !UNITY_EDITOR
+
+#if !UNITY_EDITOR
 		/// <summary>
 		/// Logs the FPS to Unity Analytics. Its rounded up into to FPS groups.
 		/// </summary>
@@ -142,6 +130,26 @@ namespace Netherlands3D.Interface
 				{ "fps", fps }
 			  });
 		}
-		#endif
+
+		/// <summary>
+		/// Method we call from javascript, telling unity if the tab/application is active.
+		/// Browsers throttle down applications in background tabs (to 1 fps) so we want to ignore those fps counts.
+		/// </summary>
+		/// <param name="isActive">Is the application active in the foreground, running at max performance, this should be 1, else 0.</param>
+		public void ActiveApplication(float isActive)
+		{
+			bool active = (isActive == 1); //We convert a number to a bool ( SendMessage from javascript only supports strings and numbers ) 
+			Debug.Log("Application is on foreground: " + active);
+			applicationIsActive = active;
+
+			//Reset coundown before logging resumes
+			if(applicationIsActive) 
+			{
+				framesAnalytics = 0;
+				lastIntervalAnalytics = timeNow;
+			}
+		}
+
+#endif
 	}
 }

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Interface/Fps.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Interface/Fps.cs
@@ -14,7 +14,6 @@ namespace Netherlands3D.Interface
 		[SerializeField]
 		private Image fpsBackground;
 
-
 		private int framesVisualFPS = 0;
 		private double lastInterval = 0;
 
@@ -24,6 +23,8 @@ namespace Netherlands3D.Interface
 		
 		private int framesAnalytics = 0;
 		private double lastIntervalAnalytics = 0;
+
+		private int minimumFramesRenderedBeforeLogging = 5;
 
 		private int analyticsFpsGroupSize = 5; //The average framerate analytics are grouped in groups with this size. A value of 5 would give groups 5,10,15, and up
 #endif
@@ -47,7 +48,7 @@ namespace Netherlands3D.Interface
 
 			framesVisualFPS = 0;
 			lastInterval = Time.realtimeSinceStartup;
-			
+
 			#if !UNITY_EDITOR
 			lastIntervalAnalytics = Time.realtimeSinceStartup;
 			framesAnalytics = 0;
@@ -102,7 +103,7 @@ namespace Netherlands3D.Interface
 			}
 
 #if !UNITY_EDITOR
-			if(logFpsGroupsToAnalytics && applicationIsActive)
+			if(logFpsGroupsToAnalytics && applicationIsActive && Time.frameCount > minimumFramesRenderedBeforeLogging)
 			{
 				++framesAnalytics;
 				if (timeNow > lastIntervalAnalytics + updateAnalyticsInterval)

--- a/3DAmsterdam/Assets/WebGLTemplates/Fullscreen3DAmsterdam/index.html
+++ b/3DAmsterdam/Assets/WebGLTemplates/Fullscreen3DAmsterdam/index.html
@@ -68,10 +68,10 @@
 	  //Start checking our browser activity
 	  document.addEventListener('visibilitychange', function () {
 			if (document.visibilityState == "hidden") {
-				unityInstance.SendMessage("FpsCounter", "Active", false);
+				unityInstance.SendMessage("FpsCounter", "ActiveApplication", 0);
 			} 
 			else {
-				unityInstance.SendMessage("FpsCounter", "Active", true);
+				unityInstance.SendMessage("FpsCounter", "ActiveApplication", 1);
 			}
 		});
 		

--- a/3DAmsterdam/Assets/WebGLTemplates/Fullscreen3DAmsterdam/index.html
+++ b/3DAmsterdam/Assets/WebGLTemplates/Fullscreen3DAmsterdam/index.html
@@ -29,7 +29,13 @@
   <script>
 	  var forceFocus = false;
 	  var unityCanvas;
-  
+	  var fileReader;
+	  
+	  var unityObjectName = "FileUploads";
+	  var objData = "";
+	  var mtlData = "";
+	  var dataType = 0;
+    
 	  var unityInstance = UnityLoader.instantiate("gameContainer", "%UNITY_WEBGL_BUILD_URL%" , {
 		  compatibilityCheck: function (unityInstance, onsuccess, onerror) {
 			if (!UnityLoader.SystemInfo.hasWebGL) {
@@ -47,12 +53,8 @@
 		  },
 		  onProgress: UnityProgress
 	  });
-	  var fileReader;
-	  var unityObjectName = "FileUploads";
-	  var objData = "";
-	  var mtlData = "";
-	  var dataType = 0;
-
+	  
+	  //Support for dragging dropping files on browser window
 	  document.addEventListener("dragover", function (event) {
 		  event.preventDefault();
 	  });
@@ -62,6 +64,17 @@
 
 		  ReadFiles(event.dataTransfer.files);
 	  });
+	  
+	  //Start checking our browser activity
+	  document.addEventListener('visibilitychange', function () {
+			if (document.visibilityState == "hidden") {
+				unityInstance.SendMessage("FpsCounter", "Active", false);
+			} 
+			else {
+				unityInstance.SendMessage("FpsCounter", "Active", true);
+			}
+		});
+		
 
 	  function UnityProgress(unityInstance, progress) {
 		  if (!unityInstance.Module) {


### PR DESCRIPTION
- detect if tab is on background via javascript, and stop logging fps (tab is throttled down)