### PR TITLE
the delay in disabled actionmap seems to simply be the velocity. just…

### DIFF
--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Cameras/GodViewCamera.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Cameras/GodViewCamera.cs
@@ -276,7 +276,10 @@ namespace Netherlands3D.Cameras
                     HandleRotationInput();
                     HandleFly();
                 }
-                EazeOutDragVelocity();
+                if (ActionHandler.actions.GodViewMouse.enabled)
+                {
+                    EazeOutDragVelocity();
+                }
             }
 
             LimitPosition();


### PR DESCRIPTION
- do an extra check if the camera actionmap is enabled if we want to apply secondary velocity motion to camera