### PR TITLE
GetTilesUnityFSAndCorrectHeightSpikes focus mainly on the large spikes + Unit tests

### DIFF
--- a/3DAmsterdam/Assets/Netherlands3D/Editor.meta
+++ b/3DAmsterdam/Assets/Netherlands3D/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5031a2d2551928d488442309354ccaac
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/3DAmsterdam/Assets/Netherlands3D/Editor/UnitTests.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Editor/UnitTests.cs
@@ -1,0 +1,86 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+using ConvertCoordinates;
+using System;
+
+public class UnitTests 
+{
+
+    [Test]
+    public void TestReplaceXY()
+    {
+        string template = "terrain/terrain_{x}_{y}.lod1.mesh";
+        var result = template.ReplaceXY(444000, 123000);
+        Assert.AreEqual("terrain/terrain_444000_123000.lod1.mesh", result);
+    }
+
+    [Test]
+    public void TestGetRDCoordinate()
+    {
+        var testFilePaths1 = new string[]{
+            "123000_443000_utrecht_lod1",
+            "utrecht_123000_443000_lod1",
+            "buildings_123000_443000.1.2",
+            "terrain_123000-443000",
+            "terrain_123000-443000-lod1",
+            "trees_123000-443000",
+            "trees_123000-443000-lod1",
+        };
+
+        foreach (var filePath in testFilePaths1)
+        {
+            var expectedRd = new Vector3RD(123000, 443000, 0);
+            var result = filePath.GetRDCoordinate();
+            Assert.AreEqual(expectedRd, result);
+        }
+
+        var testFilePaths2 = new string[]{
+            "7000_392000_zee_land_lod1",
+            "zee_land_7000_392000_lod1",
+            "buildings_7000_392000.1.2",
+            "terrain_7000-392000",
+            "terrain_7000-392000-lod1",
+            "trees_7000-392000",
+            "trees_7000-392000-lod1",
+        };
+
+        foreach (var filePath in testFilePaths2)
+        {
+            var expectedRd = new Vector3RD(7000, 392000, 0);
+            var result = filePath.GetRDCoordinate();
+            Assert.AreEqual(expectedRd, result);
+        }
+
+        var testFilePaths3 = new string[]{
+            "AssetBundles",
+            "move.py"
+        };
+
+        foreach (var filePath in testFilePaths3)
+        {
+            Assert.Throws<Exception>(
+             delegate { filePath.GetRDCoordinate(); });
+        }
+
+        Exception ex = Assert.Throws<Exception>(
+            delegate { "AssetBundles".GetRDCoordinate(); });        
+
+    }
+
+    // A UnityTest behaves like a coroutine in Play Mode. In Edit Mode you can use
+    // `yield return null;` to skip a frame.
+    [UnityTest]
+    public IEnumerator NewTestScriptWithEnumeratorPasses()
+    {
+        // Use the Assert class to test conditions.
+        // Use yield to skip a frame.
+        yield return null;
+        Assert.IsTrue(true);
+    }
+
+
+
+}

--- a/3DAmsterdam/Assets/Netherlands3D/Editor/UnitTests.cs.meta
+++ b/3DAmsterdam/Assets/Netherlands3D/Editor/UnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 24986741867ad784eae1c0371f2da42a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/AssetGeneration/TileAssetTester.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/AssetGeneration/TileAssetTester.cs
@@ -123,8 +123,8 @@ namespace Netherlands3D.AssetGeneration
 			int count = 0;
 			var files = Directory.GetFiles(path).Where(o => !o.Contains(".manifest")).ToArray();
 
-			int heightMax = 5; //vertices above this value are considered to be spikes, vlaue in meters
-			int heightMin = -5; //vertices above this value are considered to be spikes, vlaue in meters            
+			int heightMax = 15; //vertices above this value are considered to be spikes, vlaue in meters
+			int heightMin = -15; //vertices above this value are considered to be spikes, vlaue in meters            
 			int lookaroundWidth = 1; //area in meters to look around for other vertices to find common height
 
 			foreach (var file in files)
@@ -143,7 +143,7 @@ namespace Netherlands3D.AssetGeneration
 				yield return null;
 				Debug.Log($"going to process: {finfo.Name}");
 
-				var rd = GetRDFromName(finfo);
+				var rd = file.GetRDCoordinate();
 				var tilepos = CoordConvert.RDtoUnity(rd);
 
 				var assetbundle = AssetBundle.LoadFromFile(file);
@@ -163,22 +163,24 @@ namespace Netherlands3D.AssetGeneration
 					if (verts[i].y > heightMax || verts[i].y < heightMin)
 					{
 						hasspike = true;
+						verts[i].y = correctvertsAvgHeight; //for now just use the average height
 
-						var x = verts[i].x;
-						var z = verts[i].z;
-						var vertsaround = correctverts.Where(o => o.x < x + lookaroundWidth
-														&& o.x > x - lookaroundWidth
-														&& o.z < z + lookaroundWidth
-														&& o.z > z - lookaroundWidth);
-						if (vertsaround.Any())
-						{
-							var avgh = vertsaround.Max(o => o.y);
-							verts[i].y = avgh;
-						}
-						else
-						{
-							verts[i].y = correctvertsAvgHeight;
-						}
+						//experimental code, needs further testing
+						//var x = verts[i].x;
+						//var z = verts[i].z;
+						//var vertsaround = correctverts.Where(o => o.x < x + lookaroundWidth
+						//								&& o.x > x - lookaroundWidth
+						//								&& o.z < z + lookaroundWidth
+						//								&& o.z > z - lookaroundWidth);
+						//if (vertsaround.Any())
+						//{
+						//	var avgh = vertsaround.Max(o => o.y);
+						//	verts[i].y = avgh;
+						//}
+						//else
+						//{
+						//	verts[i].y = correctvertsAvgHeight;
+						//}
 					}
 				}
 
@@ -235,7 +237,7 @@ namespace Netherlands3D.AssetGeneration
 				yield return null;
 				Debug.Log($"going to process: {finfo.Name}");
 
-				var rd = GetRDFromName(finfo);
+				var rd = file.GetRDCoordinate();
 				var tilepos = CoordConvert.RDtoUnity(rd);
 
 				var assetbundle = AssetBundle.LoadFromFile(file);
@@ -284,7 +286,7 @@ namespace Netherlands3D.AssetGeneration
 			{
 				var finfo = new FileInfo(file);
 
-				var rd = GetRDFromName(finfo);
+				var rd = file.GetRDCoordinate();
 				var tilepos = CoordConvert.RDtoUnity(rd);
 
 				//var mesh = AssetDatabase.LoadAssetAtPath<Mesh>($"{dirname}/{finfo.Name}");
@@ -310,43 +312,7 @@ namespace Netherlands3D.AssetGeneration
 
 		}
 
-		Vector3RD GetRDFromName(FileInfo finfo)
-		{
-			var name = Path.GetFileNameWithoutExtension(finfo.Name).
-				Replace("trees_", "").
-				Replace("terrain_", "").
-				Replace("-lod1", "").
-				Replace("_utrecht_lod2", "");
 
-			string[] splitted;
-
-			if (name.Contains("_"))
-			{
-				splitted = name.Split('_');
-			}
-			else if (name.Contains("-"))
-			{
-				splitted = name.Split('-');
-			}
-			else
-			{
-				throw new Exception($"could not get RD coordinate of string: {name}");
-			}
-
-			Vector3RD rd = new Vector3RD();
-
-			try
-			{
-				rd.x = double.Parse(splitted[0]);
-				rd.y = double.Parse(splitted[1]);
-			}
-			catch
-			{
-			}
-
-			return rd;
-
-		}
 
 		void ReadTreesFromCsv()
 		{

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/ExtensionMethods/StringExtensions.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/ExtensionMethods/StringExtensions.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using ConvertCoordinates;
+using System.IO;
+using System.Text;
+using System;
+using System.Text.RegularExpressions;
+
+public static class StringExtensions
+{
+       
+    
+    /// <summary>
+    /// Replace the template string and fill in the x and y values
+    /// </summary>
+    /// <param name="template">The template string</param>
+    /// <param name="x">double value x</param>
+    /// <param name="y">double value y</param>
+    /// <returns>The replaced template string</returns>
+    public static string ReplaceXY(this string template, double x, double y)
+    {
+        StringBuilder sb = new StringBuilder(template);
+        sb.Replace("{x}", $"{x}");
+        sb.Replace("{y}", $"{y}");
+        return sb.ToString();        
+    }
+
+    /// <summary>
+    /// Get the RD coordinate of a files string
+    /// </summary>
+    /// <param name="filepath">string filepath</param>
+    /// <returns>The Vector3RD coordinate</returns>
+	public static Vector3RD GetRDCoordinate(this string filepath)
+	{
+		var numbers = new Regex(@"(\d{4,6})");
+
+		var matches = numbers.Matches(filepath);
+		if(matches.Count == 2)
+        {
+			return new Vector3RD()
+			{
+				x = double.Parse(matches[0].Value),
+				y = double.Parse(matches[1].Value)
+			};
+		}
+        else
+        {
+			throw new Exception($"Could not get RD coordinate of string: {filepath}");
+		}
+	}
+
+
+}

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/ExtensionMethods/StringExtensions.cs.meta
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/ExtensionMethods/StringExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eaeb9e86389f24d4186cb7a1d4b949a4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/LayerSystem/AssetbundleMeshLayer.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/LayerSystem/AssetbundleMeshLayer.cs
@@ -96,8 +96,7 @@ namespace Netherlands3D.LayerSystem
 				url = Datasets[lod].path;
 			}
 
-			url = url.Replace("{x}", tileChange.X.ToString());
-			url = url.Replace("{y}", tileChange.Y.ToString());
+			url = url.ReplaceXY(tileChange.X, tileChange.Y);			
 			using (UnityWebRequest uwr = UnityWebRequestAssetBundle.GetAssetBundle(url))
 			{
 				yield return uwr.SendWebRequest();

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Utilities/ConvertCoordinates.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Utilities/ConvertCoordinates.cs
@@ -43,6 +43,11 @@ namespace ConvertCoordinates
             y = Y;
             z = Z;
         }
+
+        public override string ToString()
+        {
+            return $"x:{x} y:{y} z:{z}";
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
- Changed the GetTilesUnityFSAndCorrectHeightSpikes function in TileAssetTester to focus it mainly on the large spikes
- Added 'editor only' unit tests for string.ReplaceXY(x,y) and string.GetRDCoordinate()
- Added ToString override in Vector3RD to have the unit tests show the expected and result values
- Created StringExtension methods ReplaceXY(x,y) and string.GetRDCoordinate()
