### PR TITLE
Bugfix/null error if mask reference is gone

### DIFF
--- a/3DAmsterdam/Assets/3DAmsterdam/Scenes/3DAmsterdam.unity
+++ b/3DAmsterdam/Assets/3DAmsterdam/Scenes/3DAmsterdam.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:75d2653555bf46e729fd8d46cc68291275cfeda1226b431c301b267e9a990c63
+oid sha256:676a5bad25a430e9271d93b90a8fb8db6db3e6b03955231b426d90ccade04e32
 size 55647

--- a/3DAmsterdam/Assets/Netherlands3D/Prefabs/Netherlands3D.prefab
+++ b/3DAmsterdam/Assets/Netherlands3D/Prefabs/Netherlands3D.prefab
@@ -141,6 +141,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7590023009504579809, guid: 7bd40661ca80b064c877e2086a503a44,
         type: 3}
+      propertyPath: mask
+      value: 
+      objectReference: {fileID: 6447320118858945106}
+    - target: {fileID: 7590023009504579809, guid: 7bd40661ca80b064c877e2086a503a44,
+        type: 3}
       propertyPath: loadingObjScreen
       value: 
       objectReference: {fileID: 5163436377003231569}

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Interface/SidePanel/PropertiesPanel.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Interface/SidePanel/PropertiesPanel.cs
@@ -107,8 +107,6 @@ namespace Netherlands3D.Interface.SidePanel
 
         private GameObject thumbnailImage = null;
 
-        public static bool ignoreNextTabSwitch = false;
-
         public int ThumbnailExclusiveLayer { get => thumbnailRenderer.gameObject.layer; }
 
 		void Awake()

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Interface/Tab.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Interface/Tab.cs
@@ -41,12 +41,6 @@ namespace Netherlands3D.Interface
 		/// <param name="open">Is this tab opened</param>
 		public void OpenTab(bool open = true)
         {
-            if (PropertiesPanel.ignoreNextTabSwitch)
-            {
-                PropertiesPanel.ignoreNextTabSwitch = false;
-                return;
-            }
-
             GetComponent<Toggle>().isOn = open;
             TabPanel.Open(open);
             if (open)

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/ModelParsing/MaterialLibrary.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/ModelParsing/MaterialLibrary.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using Netherlands3D.Interface.SidePanel;
+using Netherlands3D.ObjectInteraction;
 
 namespace Netherlands3D.ModelParsing
 {
@@ -26,36 +27,46 @@ namespace Netherlands3D.ModelParsing
 		/// Remaps materials to this object based on material name / substrings
 		/// </summary>
 		/// <param name="renderer">The GameObject containing the renderer with the materials list</param>
-		public void AutoRemap(GameObject gameObjectWithRenderer)
+		public bool AutoRemap(GameObject gameObjectWithRenderer)
 		{
 			var renderer = gameObjectWithRenderer.GetComponent<MeshRenderer>();
 			if (!renderer)
 			{
 				Debug.LogWarning("No meshrenderer found in this GameObject. Skipping auto remap.");
-				return;
+				return false;
 			}
 
             var matchedMaterialNames = FoundMatch(renderer);
             if (matchedMaterialNames.Count > 0)
             {
                 RequestConfirmationInSidePanel(renderer, matchedMaterialNames.ToArray());
-                PropertiesPanel.ignoreNextTabSwitch = true; //This blocks our tab switching away when we click to place
+                return true;
             }
+            return false;
 		}
 
         private void RequestConfirmationInSidePanel(MeshRenderer renderer, string[] matchedMaterialNames)
         {
-            //PropertiesPanel.Instance.OpenObjectInformation("", true,10);
-            //PropertiesPanel.Instance.AddTitle("Materialen gevonden");
-            PropertiesPanel.Instance.AddTextfield("Er zijn " + matchedMaterialNames.Length + " materialen gevonden die overeenkomen met die uit de bibliotheek. Wil je deze overnemen?");
-            PropertiesPanel.Instance.AddLabel("Het gaat om de volgende materialen: ");
-            PropertiesPanel.Instance.AddLabel(string.Join(",",matchedMaterialNames));
+            PropertiesPanel.Instance.OpenObjectInformation("", true,10);
+            PropertiesPanel.Instance.AddTitle("Materialen gevonden");
+            PropertiesPanel.Instance.AddTextfield("Er zijn <b>" + matchedMaterialNames.Length + " materialen*</b> gevonden die overeenkomen met die uit de bibliotheek. Wil je deze overnemen?");
             PropertiesPanel.Instance.AddActionButtonBig("Ja, neem over", (action) =>
             {
                 ApplyMaterialOverrides(renderer);
+                PropertiesPanel.Instance.OpenCustomObjects();
                 UpdateBounds();
-
             });
+            PropertiesPanel.Instance.AddActionButtonBig("Nee", (action) =>
+            {
+                PropertiesPanel.Instance.OpenCustomObjects(renderer.GetComponent<Transformable>());
+                UpdateBounds();
+            });
+
+            PropertiesPanel.Instance.AddLabel("<i>*Het gaat om de volgende materialen:</i>");
+            foreach(var materialName in matchedMaterialNames)
+            {
+                PropertiesPanel.Instance.AddTextfield($"<i>- {materialName}</i>");
+            }
             
         }
         /// <summary>

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/ModelParsing/ObjStringLoader.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/ModelParsing/ObjStringLoader.cs
@@ -152,6 +152,7 @@ namespace Netherlands3D.ModelParsing
 				newOBJLoader.gameObject.AddComponent<MeshCollider>().sharedMesh = newOBJLoader.GetComponent<MeshFilter>().sharedMesh;
 				newOBJLoader.gameObject.AddComponent<ClearMeshAndMaterialsOnDestroy>();
 				transformable = newOBJLoader.gameObject.AddComponent<Transformable>();
+				transformable.madeWithExternalTool = true;
 				transformable.mask = mask;
 
 				if (newOBJLoader.ObjectUsesRDCoordinates==false)
@@ -176,11 +177,6 @@ namespace Netherlands3D.ModelParsing
 
 			//Remove this loader from finished object
 			Destroy(newOBJLoader);
-		}
-		
-		private void RemapMaterials(GameObject gameObject)
-		{
-			MaterialLibrary.Instance.AutoRemap(gameObject);
 		}
 	}
 }

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/ObjectInteraction/Transformable.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/ObjectInteraction/Transformable.cs
@@ -79,7 +79,7 @@ namespace Netherlands3D.ObjectInteraction
 				PropertiesPanel.Instance.OpenObjectInformation("", true, 10);
 				placeOnGrid = true;
 				PropertiesPanel.Instance.AddTitle("Plaatsingsopties");
-				PropertiesPanel.Instance.AddTextfield("De afmetingen van dit object passen binnen ons grid.\nGebruik de volgende opties om direct uit te lijnen en/of het bestaande gebied te verbergen.");
+				PropertiesPanel.Instance.AddTextfield("De afmetingen van dit object passen binnen ons grid.\nGebruik de volgende opties om direct uit te lijnen en/of het bestaande gebied weg te maskeren.");
 				PropertiesPanel.Instance.AddActionCheckbox("Uitlijnen op grid", true, (action) => placeOnGrid = action);
 				PropertiesPanel.Instance.AddActionCheckbox("Gebied maskeren", maskArea, (action) =>
 				{
@@ -90,7 +90,6 @@ namespace Netherlands3D.ObjectInteraction
 					}
 				});
 			}
-			PropertiesPanel.ignoreNextTabSwitch = true; //This blocks our tab switching away when we click to place
 		}
 
 		private bool IsGridShaped(Bounds bounds)


### PR DESCRIPTION
- solved null errors when mask is missing
- removed blocking of tab switching ( was giving problems when tabs were being switched during placement )
- split up placement options, and mateiral mapping into two steps to avoid confusing. placement options can be made during placement window ( while object is stuck to mouse ) and dont need an apply button. material override does need an apply, but is not realy part of the placement option.
- added a help message to let users know they need to click to place an object
- because there is more room now in materials step, the materials found are listed now underneath eachother
- added more explanation on top of the two steps
- added property to transformable that flags it as 'made by external tool' so it only tries to do material remapping on objects that are uploaded ( not our basic shape(s))