### PR TITLE
Bugfix/upload screen stuck

### DIFF
--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Interface/WarningDialogs.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Interface/WarningDialogs.cs
@@ -30,8 +30,9 @@ namespace Netherlands3D.Interface
                     Destroy(child.gameObject);
             }
 
-            var bodyText = Instantiate(warningPrefab, this.transform);
-            bodyText.SetMessage(message);
+            var newWarning = Instantiate(warningPrefab, this.transform);
+            newWarning.SetMessage(message);
+            newWarning.transform.SetAsLastSibling();
         }
     }
 }

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Interface/WarningDialogs.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Interface/WarningDialogs.cs
@@ -32,7 +32,7 @@ namespace Netherlands3D.Interface
 
             var newWarning = Instantiate(warningPrefab, this.transform);
             newWarning.SetMessage(message);
-            newWarning.transform.SetAsLastSibling();
+            this.transform.SetAsLastSibling();
         }
     }
 }

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/ModelParsing/ObjStringLoader.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/ModelParsing/ObjStringLoader.cs
@@ -87,6 +87,15 @@ namespace Netherlands3D.ModelParsing
 		}
 
 		/// <summary>
+		/// Method to remove loading screen if somehow the import/loading was aborted
+		/// </summary>
+		public void AbortImport()
+		{
+			loadingObjScreen.Hide();
+			WarningDialogs.Instance.ShowNewDialog("Dit bestand lijkt geen .obj bestand te zijn. Controleer of je naast een .mtl bestand ook een .obj bestand heb geselecteerd.");
+		}
+
+		/// <summary>
 		/// Start the parsing of OBJ and MTL strings
 		/// </summary>
 		/// <param name="objText">The OBJ string data</param>
@@ -95,13 +104,13 @@ namespace Netherlands3D.ModelParsing
 		private IEnumerator ParseOBJFromString(string objText, string mtlText = "")
 		{
 			//Too small or empty to be OBJ content? Abort, and give some explanation to the user.
+			Debug.Log("OBJ length: " + objText.Length);
 			if (objText.Length < 5)
 			{
-				loadingObjScreen.Hide();
-				WarningDialogs.Instance.ShowNewDialog("Dit bestand lijkt geen .obj bestand te zijn. Controleer of je naast een .mtl bestand ook een .obj bestand heb geselecteerd.");
-				yield break; 
+				AbortImport();
+				yield break;
 			}
-		
+
 			//Create a new gameobject that parses OBJ lines one by one
 			var newOBJLoader = new GameObject().AddComponent<ObjLoad>();
 			float remainingLinesToParse;

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/ModelParsing/ObjStringLoader.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/ModelParsing/ObjStringLoader.cs
@@ -94,6 +94,14 @@ namespace Netherlands3D.ModelParsing
 		/// <returns></returns>
 		private IEnumerator ParseOBJFromString(string objText, string mtlText = "")
 		{
+			//Too small or empty to be OBJ content? Abort, and give some explanation to the user.
+			if (objText.Length < 5)
+			{
+				loadingObjScreen.Hide();
+				WarningDialogs.Instance.ShowNewDialog("Dit bestand lijkt geen .obj bestand te zijn. Controleer of je naast een .mtl bestand ook een .obj bestand heb geselecteerd.");
+				yield break; 
+			}
+		
 			//Create a new gameobject that parses OBJ lines one by one
 			var newOBJLoader = new GameObject().AddComponent<ObjLoad>();
 			float remainingLinesToParse;

--- a/3DAmsterdam/Assets/WebGLTemplates/Fullscreen3DAmsterdam/index.html
+++ b/3DAmsterdam/Assets/WebGLTemplates/Fullscreen3DAmsterdam/index.html
@@ -136,6 +136,11 @@
 		  //Reset file selection
 		  document.getElementById("obj").value = "";
 	  }
+	  function AbortInUnity() {
+		  console.log("Abort import in Unity");
+		  unityInstance.SendMessage(unityObjectName, "AbortImport");
+		  document.getElementById("obj").value = "";
+	  }
 
 	  function ReadFiles(selectedFiles) {
 		  //Check browser support
@@ -164,6 +169,11 @@
 					  console.log("OBJ file");
 					  objFileSelectionIndex = i;
 				  }
+			  }
+			  
+			  //Check if we at least found an obj in our selection of files
+			  if(objFileSelectionIndex == -1){
+				AbortInUnity();
 			  }
 
 			  //What to do when files are done loading

--- a/3DAmsterdam/Assets/WebGLTemplates/Fullscreen3DAmsterdam/index.html
+++ b/3DAmsterdam/Assets/WebGLTemplates/Fullscreen3DAmsterdam/index.html
@@ -174,6 +174,7 @@
 			  //Check if we at least found an obj in our selection of files
 			  if(objFileSelectionIndex == -1){
 				AbortInUnity();
+				return false;
 			  }
 
 			  //What to do when files are done loading


### PR DESCRIPTION
- check length of of to have some content before parsing
- skip upload if our selection of files did not contain an obj
- spawn a warning message (and move it on top of hierarchy) with an explanation about the obj