### PR TITLE
Hotfix: CSV file tab setter at startup

### DIFF
--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Csv/CsvFilePanel.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Csv/CsvFilePanel.cs
@@ -32,7 +32,7 @@ public class CsvFilePanel : MonoBehaviour
 
     private GameObject LocationMarkersParent;
 
-    private void Start()
+    private void Awake()
     {
         ToggleActiveEvent.Subscribe(OnToggleActive);
     }
@@ -245,16 +245,10 @@ public class CsvFilePanel : MonoBehaviour
         }
     }
 
-
     public void LoadCSVFromJavascript()
     {        
         var csv = JavascriptMethodCaller.FetchOBJDataAsString();     
         ParseCsv(csv);
-    }
-
-    void ClearUiFields()
-    {        
-        PropertiesPanel.Instance.ClearGeneratedFields(UIClearIgnoreObject);
     }
 
 #if UNITY_EDITOR


### PR DESCRIPTION
Setting the event listener to the Awake method instead of Start. 
The settings are also loaded in the Unity Start event function