### PR TITLE
Bugfix/context menu selectbyid missing methods

### DIFF
--- a/3DAmsterdam/Assets/Netherlands3D/Prefabs/UI/SidePanel/GeneratedFields/Selection/SelectionOutliner.prefab
+++ b/3DAmsterdam/Assets/Netherlands3D/Prefabs/UI/SidePanel/GeneratedFields/Selection/SelectionOutliner.prefab
@@ -60,12 +60,13 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
   m_FontData:
-    m_Font: {fileID: 12800000, guid: f6f9d17c21b381f49a9d4b06b403679b, type: 3}
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
     m_FontSize: 14
     m_FontStyle: 0
     m_BestFit: 0
@@ -142,6 +143,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -170,6 +172,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 6
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -200,6 +203,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 1909074435277348321}
+        m_TargetAssemblyTypeName: 
         m_MethodName: Select
         m_Mode: 1
         m_Arguments:
@@ -284,6 +288,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -312,6 +317,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -342,6 +348,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 1909074435277348321}
+        m_TargetAssemblyTypeName: 
         m_MethodName: Close
         m_Mode: 1
         m_Arguments:

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/BAG/SelectByID.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/BAG/SelectByID.cs
@@ -48,7 +48,14 @@ namespace Netherlands3D.LayerSystem
         {
             base.Select();
             //On a secondary click, only select if we did not make a multisselection yet.
-            if (selectedIDs.Count < 2) Select();
+            if (selectedIDs.Count < 2)
+            {
+                Select();
+            }
+            else{
+                //Simply retrigger the selection list we already have to trigger the right state for the context menu
+                HighlightObjectsWithIDs(selectedIDs);
+            }
         }
 
         public override void Deselect()


### PR DESCRIPTION
- changed selection outliner prefab font to arial (instead of removed Avenir)
- selectbyid now properly updates the contextmenu state to allow hiding of multiselects