### PR TITLE
version minor nr increment to 2.6.0

### DIFF
--- a/3DAmsterdam/ProjectSettings/ProjectSettings.asset
+++ b/3DAmsterdam/ProjectSettings/ProjectSettings.asset
@@ -127,7 +127,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 2.5.0
+  bundleVersion: 2.6.0
   preloadedAssets:
   - {fileID: 11400000, guid: d5f272a8231831941994b3ff3281aa1d, type: 2}
   metroInputSource: 0


### PR DESCRIPTION
- editable text optional for dynamic titles and key/data fields
- hex color input moved under toggleable input (closed/condensed by default)
- ability to rename own objects via title inputfield
- memory optimisation obj importers (via reader instead of splitting into large line array)
- improved/restored/simplified data generation scenes for buildings and trees layers
- extended documentation with getting started, tile data generation explanation, and faq