### PR TITLE
Feature/only topdown orto

### DIFF
--- a/3DAmsterdam/Assets/3DAmsterdam/Scenes/3DAmsterdam.unity
+++ b/3DAmsterdam/Assets/3DAmsterdam/Scenes/3DAmsterdam.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8bc1a97f69719d1b47ad56e04618d35b1916df291e98c84c3708cd1ec189e3e2
-size 107029
+oid sha256:b6976995ddbce54a954081cf9f667ff8186775cfb23a0b1736f073ba6ad7d6f6
+size 106997

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Cameras/CameraModeChanger.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Cameras/CameraModeChanger.cs
@@ -24,6 +24,12 @@ namespace Netherlands3D.Cameras
         public delegate void OnGodViewMode();
         public event OnGodViewMode OnGodViewModeEvent;
 
+        public delegate void OnOrtographicMode();
+        public event OnOrtographicMode OnOrtographicModeEvent;
+
+        public delegate void OnPerspectiveMode();
+        public event OnPerspectiveMode OnPerspectiveModeEvent;
+
         private Quaternion oldGodViewRotation;
 
         public CameraMode CameraMode { get; private set; }
@@ -32,6 +38,8 @@ namespace Netherlands3D.Cameras
 
         [SerializeField]
         private float groundTransitionOffset = 2.0f;
+
+        private bool ortographic = false;
 
         private void Awake()
         {
@@ -78,6 +86,25 @@ namespace Netherlands3D.Cameras
             {
                 StartCoroutine(streetView.MoveToPosition(cameraTransform, position + Vector3.up * groundTransitionOffset, rotation));
             }
+        }
+
+        public bool TogglePerspective()
+        {
+            ortographic = !ortographic;
+            CurrentCameraControls.ToggleOrtographic(ortographic);
+
+            //Invoke an event, so UI a.o. items can hide/show themselves
+			switch (ortographic)
+			{
+                case true:
+                    OnOrtographicModeEvent?.Invoke();
+                    break;
+                case false:
+                    OnPerspectiveModeEvent?.Invoke();
+                    break;
+            }
+
+            return ortographic;
         }
 
         /// <summary>

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Cameras/GodViewCamera.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Cameras/GodViewCamera.cs
@@ -103,7 +103,7 @@ namespace Netherlands3D.Cameras
         private float resetTransitionSpeed = 0.5f;
         private Coroutine resetNorthTransition;
 
-        void Awake()
+		void Awake()
         {
             cameraComponent = GetComponent<Camera>();
         }
@@ -570,26 +570,22 @@ namespace Netherlands3D.Cameras
             return availableActionMaps.Contains(actionMap);
         }
 
-        public bool ToggleCameraPerspective()
-        { 
-            if(cameraComponent.orthographic)
-            {
-                //Orto camera
-                cameraComponent.orthographic = false;
+        public void ToggleOrtographic(bool ortographicOn)
+        {
+            cameraComponent.orthographic = ortographicOn;
 
-                //Slide forward based on camera angle, to get an expected orto point
+            if (ortographicOn)
+            {
+                //Set the orto size according to camera height, so our fov looks a bit like the perspective fov
+                cameraComponent.orthographicSize = cameraComponent.transform.position.y;
+
+                //Slide forward based on camera angle, to get an expected centerpoint for our view
                 var forwardAmount = Vector3.Dot(cameraComponent.transform.up, Vector3.up);
                 cameraComponent.transform.Translate(cameraComponent.transform.up * forwardAmount * cameraComponent.transform.position.y);
-
-                print("Perspective");
-                return false;
+                print("Ortographic");
             }
             else{
-                //Perspective camera
-                cameraComponent.orthographic = true;
-                cameraComponent.orthographicSize = cameraComponent.transform.position.y;
-                print("Ortographic");
-                return true;
+                print("Perspective");                
             }
 		}
 	}

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Cameras/GodViewCamera.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Cameras/GodViewCamera.cs
@@ -427,9 +427,12 @@ namespace Netherlands3D.Cameras
                 cameraComponent.orthographicSize = Mathf.Clamp(cameraComponent.orthographicSize - cameraComponent.orthographicSize * zoomAmount * zoomSpeed, minOrtographicZoom, maxZoomOut);
 
                 //An ortographic camera moves towards the zoom direction point in its own 2D plane
-                var localPointPosition = cameraComponent.transform.InverseTransformPoint(zoomDirectionPoint);
-                localPointPosition.z = 0;
-                cameraComponent.transform.Translate(localPointPosition * zoomSpeed * zoomAmount);
+                if (cameraComponent.transform.position.y < maxZoomOut)
+                {
+                    var localPointPosition = cameraComponent.transform.InverseTransformPoint(zoomDirectionPoint);
+                    localPointPosition.z = 0;
+                    cameraComponent.transform.Translate(localPointPosition * zoomSpeed * zoomAmount);
+                }
             }
             else{
                 //A perspective camera moves its position towards to zoom direction point
@@ -462,13 +465,11 @@ namespace Netherlands3D.Cameras
                 this.transform.position -= dragMomentum;
             }
         }
-
         public Ray GetMainPointerRay()
         {
             var pointerPosition = Mouse.current.position.ReadValue();
             return cameraComponent.ScreenPointToRay(pointerPosition);
         }
-
         public Vector3 GetMousePositionInWorld(Vector3 optionalPositionOverride = default)
         {
             var pointerPosition = Mouse.current.position.ReadValue();

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Cameras/GodViewCamera.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Cameras/GodViewCamera.cs
@@ -25,7 +25,6 @@ namespace Netherlands3D.Cameras
         private float spinSpeed = 0.5f;
 
         private const float minOrtographicZoom = 20f;
-
         private const float maxZoomOut = 2500f;
 
         [SerializeField]
@@ -35,17 +34,10 @@ namespace Netherlands3D.Cameras
         public bool HoldingInteraction => (dragging || rotatingAroundPoint);
 
         private const float rotationSpeed = 50.0f;
-
-        private const float minAngle = -89f;
-        private const float maxAngle = 89f;
         private const float speedFactor = 50.0f;
 
         private float maxClickDragDistance = 5000.0f;
         private float maxTravelDistance = 20000.0f;
-
-        private const float rotationSensitivity = 20.0f;
-
-        private const float floorOffset = 1.8f;
 
         private Vector3 startMouseDrag;
 
@@ -413,9 +405,10 @@ namespace Netherlands3D.Cameras
             return Mathf.InverseLerp(minUndergroundY, maxZoomOut, cameraComponent.transform.position.y);
         }
 
+        //Return value representing camera height in borth ortographic as default 
         public float GetCameraHeight()
         {
-            return cameraComponent.transform.position.y;
+            return (cameraComponent.orthographic) ? cameraComponent.orthographicSize : cameraComponent.transform.position.y;
         }
 
         private void ZoomInDirection(float zoomAmount, Vector3 zoomDirectionPoint)

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Cameras/ICameraControls.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Cameras/ICameraControls.cs
@@ -15,8 +15,10 @@ namespace Netherlands3D.Cameras
         float GetCameraHeight();
 
         void SetNormalizedCameraHeight(float height);
-		bool ToggleCameraPerspective();
-		void MoveAndFocusOnLocation(Vector3 targetLocation, Quaternion rotation);
+
+        void ToggleOrtographic(bool ortographicOn);
+
+        void MoveAndFocusOnLocation(Vector3 targetLocation, Quaternion rotation);
 
         Vector3 GetMousePositionInWorld(Vector3 optionalPositionOverride = default);
 

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Cameras/StreetViewCamera.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Cameras/StreetViewCamera.cs
@@ -218,16 +218,18 @@ namespace Netherlands3D.Cameras
 			//Not implemented
 		}
 
-		public bool ToggleCameraPerspective()
+		/// <summary>
+		/// Ortographic wouldnt make sense in an FPS camera, but we can change the fov to something a little less extreme as a fallback.
+		/// </summary>
+		/// <returns>Ortographic on</returns>
+		public void ToggleOrtographic(bool ortographicOn)
 		{
-			if (cameraComponent.fieldOfView != 60)
+			if (ortographicOn)
 			{
-				cameraComponent.fieldOfView = 60;
-				return false;
+				cameraComponent.fieldOfView = 30;
 			}
 
-			cameraComponent.fieldOfView = 30;
-			return true;
+			cameraComponent.fieldOfView = 60;
 		}
 	}
 }

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Interface/CameraHeightSlider.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Interface/CameraHeightSlider.cs
@@ -18,6 +18,8 @@ namespace Netherlands3D.Interface
 
         private float heightInNAP;
 
+        private Graphic[] allGraphics;
+
         private void Awake()
         {
             slider = GetComponent<Slider>();
@@ -25,6 +27,24 @@ namespace Netherlands3D.Interface
             {
                 mode = Navigation.Mode.None
             };
+        }
+
+		private void Start()
+		{
+            CameraModeChanger.Instance.OnGodViewModeEvent += EnableObject;
+            CameraModeChanger.Instance.OnFirstPersonModeEvent += DisableObject;
+
+            CameraModeChanger.Instance.OnOrtographicModeEvent += DisableObject;
+            CameraModeChanger.Instance.OnPerspectiveModeEvent += EnableObject;
+        }
+
+        private void EnableObject()
+        {
+            gameObject.SetActive(true);
+		}
+        private void DisableObject()
+        {
+            gameObject.SetActive(false);
         }
 
         public void HeightSliderChanged(float sliderValue)

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Interface/CameraHeightSlider.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Interface/CameraHeightSlider.cs
@@ -18,8 +18,6 @@ namespace Netherlands3D.Interface
 
         private float heightInNAP;
 
-        private Graphic[] allGraphics;
-
         private void Awake()
         {
             slider = GetComponent<Slider>();

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Interface/Measuring/MeasuringLine.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Interface/Measuring/MeasuringLine.cs
@@ -260,7 +260,7 @@ public class MeasuringLine : Interactable
 		lineRenderer.SetPositions(positions);
 
 		//Draw the distance text on top of our line if points differ
-		if (positions[0] != positions[1])
+		if (positions[0] != positions[1] || Selector.doingMultiselect)
 		{
 			var lineCenter = Vector3.Lerp(positions[0], positions[1], 0.5f);
 			if (!distanceText) distanceText = CoordinateNumbers.Instance.CreateDistanceNumber();

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Interface/PerspectiveSwitch.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Interface/PerspectiveSwitch.cs
@@ -9,9 +9,23 @@ public class PerspectiveSwitch : MonoBehaviour
     [SerializeField]
     private Image perspectiveIcon, ortographicIcon;
 
+    void Start(){
+        CameraModeChanger.Instance.OnGodViewModeEvent += EnableObject;
+        CameraModeChanger.Instance.OnFirstPersonModeEvent += DisableObject;
+    }
+
+    private void EnableObject()
+    {
+        gameObject.SetActive(true);
+    }
+    private void DisableObject()
+    {
+        gameObject.SetActive(false);
+    }
+
     public void ToggleCameraPerspective()
     {
-        bool cameraIsPerspective = CameraModeChanger.Instance.CurrentCameraControls.ToggleCameraPerspective();
+        bool cameraIsPerspective = CameraModeChanger.Instance.TogglePerspective();
 
         perspectiveIcon.gameObject.SetActive(!cameraIsPerspective);
         ortographicIcon.gameObject.SetActive(cameraIsPerspective);

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Masking/MaskDome.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Masking/MaskDome.cs
@@ -49,7 +49,7 @@ namespace Netherlands3D.Masking
             }
 
             transform.position = CameraModeChanger.Instance.CurrentCameraControls.GetMousePositionInWorld();
-            transform.transform.localScale = Vector3.one * runtimeMask.MaskScaleMultiplier * CameraModeChanger.Instance.ActiveCamera.transform.position.y;
+            transform.transform.localScale = Vector3.one * runtimeMask.MaskScaleMultiplier * CameraModeChanger.Instance.CurrentCameraControls.GetCameraHeight();
         }
     }
 }


### PR DESCRIPTION
- orto toggle only looks straight down ( with rotation over one axis )
- orto camera size matches y position as much as possible so distance based 3D items scale properly
- compass double click logic disabled (no need)
- height measure tool always shows height (even when measured distance is 0)