### PR TITLE
Feature/analytics performance seperate

### DIFF
--- a/3DAmsterdam/Assets/3DAmsterdam/Scenes/3DAmsterdam.unity
+++ b/3DAmsterdam/Assets/3DAmsterdam/Scenes/3DAmsterdam.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:df9f748d7a0f4bedf144b9bc41395306ac9a643e97694cacbd1cfae8ef367607
-size 125071
+oid sha256:a65e48dc64499a54d35da597d8eb2f6bc23a27f1506fa0347a7911bd0d3fc1ac
+size 125104

--- a/3DAmsterdam/Assets/Netherlands3D/Prefabs/Analytics/Analytics.prefab
+++ b/3DAmsterdam/Assets/Netherlands3D/Prefabs/Analytics/Analytics.prefab
@@ -46,7 +46,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   analyticsServices:
   - {fileID: 3719731222783805292}
-  logInConsole: 0
+  logInConsole: 1
 --- !u!114 &3719731222783805292
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/3DAmsterdam/Assets/Netherlands3D/Prefabs/UI/SidePanel/PropertiesTabs.prefab
+++ b/3DAmsterdam/Assets/Netherlands3D/Prefabs/UI/SidePanel/PropertiesTabs.prefab
@@ -3681,7 +3681,7 @@ GameObject:
   - component: {fileID: 1259379766041023407}
   - component: {fileID: 473357344793909176}
   m_Layer: 5
-  m_Name: GeneratedFieldsContainer
+  m_Name: SearchResultsContainer
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -6922,6 +6922,31 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1470425302238904585, guid: 3dc7d6565028ae74d8b838a385f795d1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1470425302238904585, guid: 3dc7d6565028ae74d8b838a385f795d1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1470425302238904585, guid: 3dc7d6565028ae74d8b838a385f795d1,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1470425302238904585, guid: 3dc7d6565028ae74d8b838a385f795d1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1470425302238904585, guid: 3dc7d6565028ae74d8b838a385f795d1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1943668102206348607, guid: 3dc7d6565028ae74d8b838a385f795d1,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -7338,6 +7363,31 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5356920309308962003, guid: 3dc7d6565028ae74d8b838a385f795d1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5470455706731051865, guid: 3dc7d6565028ae74d8b838a385f795d1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5470455706731051865, guid: 3dc7d6565028ae74d8b838a385f795d1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5470455706731051865, guid: 3dc7d6565028ae74d8b838a385f795d1,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5470455706731051865, guid: 3dc7d6565028ae74d8b838a385f795d1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5470455706731051865, guid: 3dc7d6565028ae74d8b838a385f795d1,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Logging/Analytics.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Logging/Analytics.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
 using Netherlands3D.Logging.Services;
+using Netherlands3D.Interface;
 
 namespace Netherlands3D.Logging
 {
@@ -43,16 +44,27 @@ namespace Netherlands3D.Logging
 		/// <param name="eventData">Event data with field names and their values</param>
 		public static void SendEvent(string category, string action, string label = "")
 		{
+			#if UNITY_EDITOR
 			//Show our events in the console
 			if(Instance.logInConsole)
 			{
-				Debug.Log($"<color={ConsoleColors.EventHexColor}>[Analytics Event]  {category},{action},{label} (Not sent in Editor)</color>");
+				Debug.Log($"<color={ConsoleColors.EventHexColor}><b>[Analytics Event]</b> {category},{action},{label}</color>");
+				if(Fps.fpsLogGroup != 0)
+					Debug.Log($"<color={ConsoleColors.EventHexColor}><b>[Analytics Performance Event]</b> Fps group:{Fps.fpsLogGroup}</color>");
 			}
+			#endif
 
 			//Send the event down to our analytics service(s)
 			foreach (var service in Instance.analyticsServices)
 			{
-				if(service.enabled) service.SendEvent(category, action, label);
+				if (service.enabled)
+				{
+					service.SendEvent(category, action, label);
+
+					//We send average framerate after every action, as fps groups
+					if(Fps.fpsLogGroup != 0)
+						service.SendEvent("Performance", "FPS", $"{Fps.fpsLogGroup}");
+				}
 			}			
 		}
 

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Logging/AnalyticsClickTrigger.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Logging/AnalyticsClickTrigger.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using UnityEngine.UI;
 
 namespace Netherlands3D.Logging
 {
@@ -12,7 +13,16 @@ namespace Netherlands3D.Logging
             var selectedName = this.gameObject.name;
             var containerName = (this.transform.parent) ? this.transform.parent.name : "Root";
 
-            Analytics.SendEvent($"{containerName}", selectedName);
+            //Optionaly send the state of a toggle (on/off) after we clicked it
+            var toggle = GetComponent<Toggle>();
+            if(toggle && (!toggle.group || (toggle.group && toggle.group.allowSwitchOff)))
+            {
+                //Togle isOn value is set after pointer up. So we read the opposite to log on/off:
+                Analytics.SendEvent($"{containerName}", selectedName, (toggle.isOn) ? "Off" : "On");
+			}
+            else{
+                Analytics.SendEvent($"{containerName}", selectedName);
+            }
         }
     }
 }

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Logging/Services/SiteImproveAnalyticsService.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Logging/Services/SiteImproveAnalyticsService.cs
@@ -1,3 +1,4 @@
+using Netherlands3D.Interface;
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
@@ -13,7 +14,7 @@ namespace Netherlands3D.Logging.Services
 		private static extern void PushEvent(string category = "category", string action = "action", string label = "label");
 
 		public override void SendEvent(string category, string action, string label = "")
-		{
+		{		
 #if !UNITY_EDITOR && UNITY_WEBGL
 			PushEvent(category, action, label);
 #endif


### PR DESCRIPTION
- moved fps performance ticks into seperate events, fired on user actions ( to avoid flooding of siteimprove analytics tool )