### PR TITLE
Bugfix/delete mtl from indexeddb

### DIFF
--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/ModelParsing/ObjStringLoader.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/ModelParsing/ObjStringLoader.cs
@@ -138,7 +138,6 @@ namespace Netherlands3D.ModelParsing
 				if (extention.IndexOf("mtl") > -1)
 				{
 					mtlstring = filenames[i];
-
 				}
 			}
 
@@ -153,7 +152,6 @@ namespace Netherlands3D.ModelParsing
 			loadingObjScreen.Hide();
 			WarningDialogs.Instance.ShowNewDialog("U kunt maximaal één .obj tegelijk importeren met optioneel daarnaast een bijbehorend .mtl bestand.");
 		}
-
 
 		private IEnumerator ParseOBJfromStream(string objFilePath, string mtlFilePath, System.Action<bool> callback)
         {
@@ -196,11 +194,7 @@ namespace Netherlands3D.ModelParsing
 			}
 
 			GameObject createdGO = objstreamReader.createdGameObject;
-
 			createdGO.name = objModelName;
-
-			//newOBJLoader.name = objModelName;
-
 			createdGO.AddComponent<MeshCollider>().sharedMesh = createdGO.GetComponent<MeshFilter>().sharedMesh;
 			createdGO.AddComponent<ClearMeshAndMaterialsOnDestroy>();
 			transformable = createdGO.AddComponent<Transformable>();
@@ -212,7 +206,6 @@ namespace Netherlands3D.ModelParsing
 				if (transformable.placedTransformable == null) transformable.placedTransformable = new ObjectPlacedEvent();
 				//transformable.placedTransformable.AddListener(RemapMaterials);
 				customObjectPlacer.PlaceExistingObjectAtPointer(createdGO);
-				
 			}
 			else
 			{

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/ModelParsing/ObjStringLoader.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/ModelParsing/ObjStringLoader.cs
@@ -182,8 +182,9 @@ namespace Netherlands3D.ModelParsing
 					isBusy = mtlreader.isBusy;
 					yield return null;
 				}
-				
+				File.Delete(Application.persistentDataPath + "/" + mtlFilePath);
 			}
+
 			objstreamReader.materialDataSlots = mtlreader.GetMaterialData();
 			objstreamReader.CreateGameObject(defaultLoadedObjectsMaterial);
 			isBusy = true;

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/ModelParsing/ReadMTL.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/ModelParsing/ReadMTL.cs
@@ -93,7 +93,6 @@ namespace Netherlands3D.ModelParsing
             }
 
             isBusy = false;
-
         }
 
         public int ParseNextMtlLines(int maxLines)

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/ModelParsing/StreamreadOBJ.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/ModelParsing/StreamreadOBJ.cs
@@ -70,8 +70,6 @@ namespace Netherlands3D.ModelParsing
 		public Vector2RD TopRightBounds { get => topRightBounds; set => topRightBounds = value; }
 		//public GeometryBuffer Buffer { get => buffer; set => buffer = value; }
 
-
-
 		StreamReader streamReader;
 		public bool isFinished = false;
 		public bool succes = true;
@@ -137,8 +135,6 @@ namespace Netherlands3D.ModelParsing
 		{
 			faces.Capacity = 4;
 			
-
-
 			if (!File.Exists(Application.persistentDataPath + "/" + filename))
 			{
 				Debug.Log("can't find file");
@@ -152,7 +148,6 @@ namespace Netherlands3D.ModelParsing
 
 		IEnumerator StreamReadFile(string filename)
 		{
-
 			vertices.SetupWriting("vertices");
 			normals.SetupWriting("normals");
 			//setup first submesh;
@@ -183,8 +178,6 @@ namespace Netherlands3D.ModelParsing
 				lineCount++;
 				totalLinesCount++;
 				ReadLine();
-
-
 			}
 
 			streamReader.Close();
@@ -494,9 +487,6 @@ namespace Netherlands3D.ModelParsing
 
 		void ReadVertex()
 		{
-
-
-
 			float x = ReadFloat();
 			float y = ReadFloat();
 			float z = ReadFloat();
@@ -550,7 +540,6 @@ namespace Netherlands3D.ModelParsing
 
 		void ReadVertexTexture()
 		{
-
 			float x = ReadFloat();
 			float y = ReadFloat();
 			if (x != float.NaN && y != float.NaN)
@@ -615,12 +604,9 @@ namespace Netherlands3D.ModelParsing
 		}
 		void SaveVertexToSubmesh(GeometryBuffer.FaceIndices v1)
         {
-
 			activeSubmesh.rawData.Add(v1.vertexIndex, v1.vertexNormal, v1.vertexUV);
 			activeSubmesh.vertexCount++;
 			return;
-			
-
 		}
 
 		bool ReadSingleFace(out GeometryBuffer.FaceIndices faceIndex, out char readChar)
@@ -630,7 +616,7 @@ namespace Netherlands3D.ModelParsing
 			int number;
 			char lastChar;
 
-			if (readInt(out number, out lastChar))
+			if (ReadInt(out number, out lastChar))
 			{
                 if (number<0)
                 {
@@ -640,12 +626,12 @@ namespace Netherlands3D.ModelParsing
 				if (lastChar == '/') // vertex is followed by texture and / or normal;
 				{
 
-					if (readInt(out number, out lastChar))
+					if (ReadInt(out number, out lastChar))
 
 					{// succesfully read vertexUV
 						face.vertexUV = number - 1;
 					}
-					if (readInt(out number, out lastChar))
+					if (ReadInt(out number, out lastChar))
 					{ 
                         if (number<0)
                         {
@@ -668,7 +654,7 @@ namespace Netherlands3D.ModelParsing
 			return true;
 		}
 
-		bool readInt(out int number, out char lastChar)
+		bool ReadInt(out int number, out char lastChar)
 		{// return if succesfully found a bool
 			char readChar = ' ';
 			bool numberFound = false;
@@ -709,7 +695,6 @@ namespace Netherlands3D.ModelParsing
 		}
 		void ReadNormal()
 		{
-
 			float x = ReadFloat();
 			float y = ReadFloat();
 			float z = ReadFloat();
@@ -1050,8 +1035,6 @@ namespace Netherlands3D.ModelParsing
 
 			mesh.subMeshCount = submeshes.Count;
 
-
-
 			int submeshIndex = 0;
             foreach (var sm in submeshes)
             {
@@ -1086,20 +1069,11 @@ namespace Netherlands3D.ModelParsing
 			{
 				mesh.RecalculateNormals();
 			}
-				
-
-
-			//         submeshes.Clear();
-
-
-			////set up all the materials;
-			////mesh.RecalculateNormals();
 			createdGameObject = new GameObject();
             MeshFilter mf = createdGameObject.AddComponent<MeshFilter>();
             MeshRenderer mr = createdGameObject.AddComponent<MeshRenderer>();
             mr.materials = materials;
             mf.mesh = mesh;
-
 
 			loadingObjScreen.Hide();
 			isFinished = true;
@@ -1112,7 +1086,4 @@ namespace Netherlands3D.ModelParsing
 			return norm;
 		}
 	}
-	
-
-	
 }


### PR DESCRIPTION
- .mtl files are now removed from indexeddb scratch space after parsing, just like their .obj files