### PR TITLE
filter forbidden characters from layername (=materialname)

### DIFF
--- a/3DAmsterdam/Assets/Netherlands3D/Plugins/netDxf/DXFCreation.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Plugins/netDxf/DXFCreation.cs
@@ -52,6 +52,20 @@ public class DXFCreation : ModelFormatCreation
                 for (int submeshID = 0; submeshID < gameObject.GetComponent<MeshFilter>().sharedMesh.subMeshCount; submeshID++)
                 {
                     string layerName = gameObject.GetComponent<MeshRenderer>().sharedMaterials[submeshID].name.Replace(" (Instance)","");
+                    layerName = layerName.Replace("=", "");
+                    layerName = layerName.Replace("\\", "");
+                    layerName = layerName.Replace("<", "");
+                    layerName = layerName.Replace(">", "");
+                    layerName = layerName.Replace("/", "");
+                    layerName = layerName.Replace("?", "");
+                    layerName = layerName.Replace("\"" ,"");
+                    layerName = layerName.Replace(":", "");
+                    layerName = layerName.Replace(";", "");
+                    layerName = layerName.Replace("*", "");
+                    layerName = layerName.Replace("|", "");
+                    layerName = layerName.Replace(",", "");
+                    layerName = layerName.Replace("'", "");
+
                     loadingScreen.ProgressBar.SetMessage("Laag '" + layer.name + "' object " + layerName + " wordt uitgesneden...");
                     yield return new WaitForEndOfFrame();
 


### PR DESCRIPTION
treematerial-name is used for the layername in the dxf-exporter. treematerial-name contains a character that isn't aloowed by the dxf-exporter. added code to remove all the illegal characters from the layername.