### PR TITLE
Bugfix/collada export

### DIFF
--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/ModelExporting/ColladaCreation.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/ModelExporting/ColladaCreation.cs
@@ -87,7 +87,7 @@ public class ColladaCreation : ModelFormatCreation
         yield return new WaitForEndOfFrame();
 
         //Create the collada file XML contents, and add our geo info (supported from collada 1.5)
-        colladaFile.CreateCollada(true,CoordConvert.UnitytoWGS84(UnityBounds.min));
+        colladaFile.CreateCollada(false,CoordConvert.UnitytoWGS84(UnityBounds.min));
 
         //Save the collada file, with the coordinates embedded in the name.
         colladaFile.Save("Collada-RD-" + bottomLeftRD.x.ToString(CultureInfo.InvariantCulture) + "_" + bottomLeftRD.y.ToString(CultureInfo.InvariantCulture) + ".dae");

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/ModelExporting/ColladaFile.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/ModelExporting/ColladaFile.cs
@@ -359,7 +359,7 @@ public class ColladaFile
 		writer.WriteStartDocument(false);
 		writer.WriteStartElement("COLLADA");
 		writer.WriteAttributeString("xmlns", "http://www.collada.org/2008/03/COLLADASchema");
-		writer.WriteAttributeString("version", "1.5.1");
+		writer.WriteAttributeString("version", "1.4.1");
 	}
 
 	private void WriteAssetHeader()

--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/ModelExporting/ColladaFile.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/ModelExporting/ColladaFile.cs
@@ -74,7 +74,7 @@ public class ColladaFile
 		}
 		writer.WriteEndElement();
 
-		//Library for materials
+		//Library for materials 
 		writer.WriteStartElement("library_materials");
 		foreach (Material material in materials)
 		{
@@ -307,9 +307,9 @@ public class ColladaFile
 	private void WriteMaterial(Material material)
 	{
 		writer.WriteStartElement("material");
-		writer.WriteAttributeString("id", material.name);
+		writer.WriteAttributeString("id", material.name.Split(' ')[0]);
 		writer.WriteStartElement("instance_effect");
-		writer.WriteAttributeString("url", "#" + material.name + "-effect");
+		writer.WriteAttributeString("url", "#" + material.name.Split(' ')[0] + "-effect");
 		writer.WriteEndElement();
 		writer.WriteEndElement();
 	}


### PR DESCRIPTION
-removed header with location info (only supported by collada 1.5, and not 1.4.1. SketchUp importer is based on 1.4.1
-make sure all tags and weird characters are removed in material names / ids