### PR TITLE
respect fov based on 60 fov ( previous default )

### DIFF
--- a/3DAmsterdam/Assets/Netherlands3D/Scripts/Masking/MaskDome.cs
+++ b/3DAmsterdam/Assets/Netherlands3D/Scripts/Masking/MaskDome.cs
@@ -53,7 +53,7 @@ namespace Netherlands3D.Masking
             }
 
             transform.position = CameraModeChanger.Instance.CurrentCameraControls.GetPointerPositionInWorld();
-            transform.transform.localScale = Vector3.one * runtimeMask.MaskScaleMultiplier * CameraModeChanger.Instance.CurrentCameraControls.GetCameraHeight();
+            transform.transform.localScale = Vector3.one * runtimeMask.MaskScaleMultiplier * CameraModeChanger.Instance.CurrentCameraControls.GetCameraHeight() * (((CameraModeChanger.Instance.ActiveCamera.orthographic) ? 1.0f : (CameraModeChanger.Instance.ActiveCamera.fieldOfView/60)));
         }
     }
 }


### PR DESCRIPTION
dome scales according camera fov next to height (maintaining similar scale in screen in different fovs)